### PR TITLE
Update Automatisering

### DIFF
--- a/Automatisering
+++ b/Automatisering
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Versie 20251020
+description: Versie 20251026
 triggers:
   - seconds: /4
     id: aansturing_trigger
@@ -286,6 +286,10 @@ actions:
                   ==
                      states('sensor.zendure_2400_ac_maximale_laadpercentage') | float(0) }}
                 alias: Maximale ingestelde SOC bereikt
+              - trigger: state
+                entity_id:
+                  - input_select.zendure_2400_ac_modus_selecteren
+                from: Dynamisch NOM
             continue_on_timeout: false
           - action: rest_command.zendure_stop_met_alles
             data:


### PR DESCRIPTION
- Zodra Dynamisch NOM goedkoop ging laden reageert de batterij niet meer op verandering van de modus wat onwenselijk is. Dit is nu opgelost.