### PR TITLE
Fix dynamic trading: replace % spread with absolute ct/kWh spread

### DIFF
--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -167,11 +167,11 @@ input_number:
 
   dynamisch_minimale_spread:
     name: Dynamisch Minimale Spread
-    icon: mdi:percent-box
+    icon: mdi:cash
     min: 0
     max: 100
     step: 1
-    unit_of_measurement: '%'
+    unit_of_measurement: 'ct/kWh'
     mode: box
 
   dynamisch_goedkoopste_x_periode:
@@ -553,7 +553,7 @@ template:
               0
             {% endif %}
           min_tomorrow: >-
-            {% set data = state_attr('sensor.dynamisch_nordpool','raw_today') %}
+            {% set data = state_attr('sensor.dynamisch_nordpool','raw_tomorrow') %}
             {% if data %}
             {{ data | map(attribute='value') | min | round(5) }}
             {% else %}
@@ -576,8 +576,8 @@ template:
 
       - name: "Dynamisch Spread Indicatie"
         unique_id: dynamisch_spread_indicatie
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
@@ -585,7 +585,7 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -650,8 +650,8 @@ template:
 
       - name: "Dynamisch Spread Indicatie NOM"
         unique_id: dynamisch_spread_indicatie_NOM
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
           {% set duurste = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
@@ -662,7 +662,7 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -727,8 +727,8 @@ template:
 
       - name: "Dynamisch Spread Indicatie Morgen"
         unique_id: dynamisch_spread_indicatie_morgen
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
@@ -736,7 +736,7 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -801,8 +801,8 @@ template:
 
       - name: "Dynamisch Spread Indicatie NOM Morgen"
         unique_id: dynamisch_spread_indicatie_nom_morgen
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
           {% set duurste = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope_morgen') or [] %}
@@ -811,7 +811,7 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -167,11 +167,11 @@ input_number:
 
   dynamic_setting_minimal_spread:
     name: Dynamic Minimal Spread
-    icon: mdi:percent-box
+    icon: mdi:cash
     min: 0
     max: 100
     step: 1
-    unit_of_measurement: '%'
+    unit_of_measurement: 'ct/kWh'
     mode: box
 
   dynamic_lowest_price_x_period:
@@ -553,7 +553,7 @@ template:
               0
             {% endif %}
           min_tomorrow: >-
-            {% set data = state_attr('sensor.dynamic_nordpool','raw_today') %}
+            {% set data = state_attr('sensor.dynamic_nordpool','raw_tomorrow') %}
             {% if data %}
             {{ data | map(attribute='value') | min | round(5) }}
             {% else %}
@@ -576,8 +576,8 @@ template:
 
       - name: "Dynamic Spread Indication"
         unique_id: dynamic_spread_indication
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
@@ -585,7 +585,7 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -650,8 +650,8 @@ template:
 
       - name: "Dynamic Spread Indication DSC"
         unique_id: dynamic_spread_indication_dsc
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
           {% set duurste = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
@@ -662,7 +662,7 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -727,8 +727,8 @@ template:
 
       - name: "Dynamic Spread Indication Tomorrow"
         unique_id: dynamic_spread_indication_tomorrow
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
@@ -736,7 +736,7 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}
@@ -801,8 +801,8 @@ template:
 
       - name: "Dynamic Spread Indication DSC Tomorrow"
         unique_id: dynamic_spread_indication_dsc_tomorrow
-        icon: mdi:percent-box
-        unit_of_measurement: "%"
+        icon: mdi:cash
+        unit_of_measurement: "ct/kWh"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
           {% set duurste = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope_tomorrow') or [] %}
@@ -811,7 +811,7 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / avg_goedkoop * 100) | round(1) }}
+            {{ ((avg_duur - avg_goedkoop) * 100) | round(1) }}
           {% else %}
             0
           {% endif %}


### PR DESCRIPTION
## Problem

The dynamic trading mode uses a percentage-based spread formula to decide whether to charge/discharge:

```
spread = (avg_expensive - avg_cheap) / avg_cheap * 100
```

This formula breaks when electricity prices are **negative or zero**, which is increasingly common with high renewable generation:

| cheap | expensive | formula result | correct spread |
|-------|-----------|----------------|----------------|
| -0.10 | +0.40 | **-500%** | 50 ct/kWh |
| 0.00 | +0.25 | **division by zero** | 25 ct/kWh |
| -0.05 | -0.01 | **-80%** | 4 ct/kWh |

Because the condition `spread >= minimal_spread` fails in these cases, the automation **does not trade even when the price difference is economically favourable**.

## Solution

Replace the percentage formula with an absolute spread in **ct/kWh**:

```
spread = (avg_expensive - avg_cheap) × 100
```

This works correctly at all price levels including negative prices.

## Changes

- **4 spread sensors** updated (today, today NOM, tomorrow, tomorrow NOM — both NL and EN packages):
  - Formula: `/ avg_goedkoop * 100` → `* 100`
  - Icon: `mdi:percent-box` → `mdi:cash`
  - Unit: `%` → `ct/kWh`
- **`input_number` minimal spread** unit changed from `%` to `ct/kWh` (entity IDs unchanged, no automation changes needed)
- **Bugfix**: `min_tomorrow` attribute in `sensor.dynamisch_nordpool` / `sensor.dynamic_nordpool` was reading from `raw_today` instead of `raw_tomorrow`

## Breaking change

The saved value for the minimal spread input is reinterpreted: a value of `20` previously meant 20%, now means **20 ct/kWh**. Users should update this value in Home Assistant after installing.

## Acceptance criteria

| Scenario | cheap | expensive | Expected spread | Trade at min=15? |
|----------|-------|-----------|-----------------|------------------|
| A | -0.10 | +0.40 | 50.0 ct/kWh | ✅ yes |
| B | +0.20 | +0.30 | 10.0 ct/kWh | ❌ no |
| C | 0.00 | +0.25 | 25.0 ct/kWh | ✅ yes (no div/0) |
| D | -0.05 | -0.01 | 4.0 ct/kWh | ❌ no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)