### PR TITLE
Add division-by-zero guard in package

### DIFF
--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -619,7 +619,11 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% if avg_goedkoop == 0 %}
+              0
+            {% else %}
+              {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% endif %}            
           {% else %}
             0
           {% endif %}
@@ -696,7 +700,11 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% if avg_goedkoop == 0 %}
+              0
+            {% else %}
+              {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% endif %}
           {% else %}
             0
           {% endif %}

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -619,7 +619,11 @@ template:
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
             {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
-            {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% if avg_goedkoop == 0 %}
+              0
+            {% else %}
+              {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% endif %}
           {% else %}
             0
           {% endif %}
@@ -696,7 +700,11 @@ template:
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
             {% set avg_duur = dure_uren | map(attribute='value') | sum / dure_uren | count %}
-            {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% if avg_goedkoop == 0 %}
+              0
+            {% else %}
+              {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% endif %}
           {% else %}
             0
           {% endif %}


### PR DESCRIPTION
Add guard avg_goedkoop == 0 before calculating price spread percentage.

I noticed some errors on the dashboard and in the logs when running the ZenSDK related to the following sensors:
- dynamic_spread_indication
- dynamic_spread_indication_dsc

It happened because dynamic prices in The Netherlands where exactly "0" for a couple of hours on the 9th of May.

```
2026-05-09 13:16:42.398 ERROR (MainThread) [homeassistant.components.template.template_entity] TemplateError('ZeroDivisionError: division by zero') while processing template 'Template<template=({% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %} {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %} {% set duur = uren | selectattr('duur','equalto','Yes') | list %} {% if goedkoop | count > 0 and duur | count > 0 %}
```

Alternatively I could write the following solution:
```
{% if avg_goedkoop == 0 %}
  0
{% else %}
  {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
{% endif %}
```

Like this:
`{{ 0 if avg_goedkoop == 0 else ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}`

I went for the first one since this is more explicit.