### PR TITLE
Add RTE break-even floor to dynamic trading charge decisions

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1571,6 +1571,23 @@ actions:
             value_template: >-
               {{ states('sensor.dynamisch_spread_indicatie_nom') | float >=
               states('input_number.dynamisch_minimale_spread') | float }}
+          - alias: >-
+              RTE break-even: gem. dure periode x RTE moet hoger zijn dan de gem.
+              goedkope inkoopprijs (blokkeert laden bij een verlieslatende cyclus)
+            condition: template
+            value_template: >-
+              {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+              {% set duurste = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
+              {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+              {% set duur = duurste | list %}
+              {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamisch_rte_effectief') | float(1.0) %}
+              {{ (avg_duur * factor - avg_goedkoop) > 0 }}
+              {% else %}
+              true
+              {% endif %}
           - condition: state
             entity_id: input_boolean.dynamisch_laden_loopt
             state:
@@ -1691,6 +1708,22 @@ actions:
             value_template: >-
               {{ states('sensor.dynamisch_spread_indicatie') | float >=
               states('input_number.dynamisch_minimale_spread') | float }}
+          - alias: >-
+              RTE break-even: gem. dure periode x RTE moet hoger zijn dan de gem.
+              goedkope inkoopprijs (blokkeert laden bij een verlieslatende cyclus)
+            condition: template
+            value_template: >-
+              {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+              {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+              {% set duur = uren | selectattr('duur','equalto','ja') | list %}
+              {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamisch_rte_effectief') | float(1.0) %}
+              {{ (avg_duur * factor - avg_goedkoop) > 0 }}
+              {% else %}
+              true
+              {% endif %}
           - condition: state
             entity_id: input_boolean.dynamisch_laden_loopt
             state:

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -685,6 +685,18 @@ template:
             {% else %}
               n.v.t.
             {% endif %}
+          netto_spread: >
+            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+            {% set duur = uren | selectattr('duur','equalto','ja') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamisch_rte_effectief') | float(1.0) %}
+              {{ ((avg_duur * factor - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% else %}
+              0
+            {% endif %}
 
       - name: "Dynamisch Spread Indicatie NOM"
         unique_id: dynamisch_spread_indicatie_NOM
@@ -761,6 +773,19 @@ template:
               €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
             {% else %}
               n.v.t.
+            {% endif %}
+          netto_spread: >
+            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+            {% set duurste = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+            {% set duur = duurste | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamisch_rte_effectief') | float(1.0) %}
+              {{ ((avg_duur * factor - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% else %}
+              0
             {% endif %}
 
       - name: "Dynamisch Spread Indicatie Morgen"
@@ -1457,6 +1482,24 @@ template:
           {% else %}
             0
           {% endif %}
+
+      - name: "Dynamisch RTE Effectief"
+        unique_id: dynamisch_rte_effectief
+        icon: mdi:battery-sync
+        state: >
+          {% set r = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
+          {{ ((r / 100) if 50 <= r <= 100 else 1.0) | round(4) }}
+        attributes:
+          rte_totaal_percentage: >
+            {% set r = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
+            {{ r }}
+          correctie_actief: >
+            {% set r = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
+            {{ 50 <= r <= 100 }}
+          break_even_spread_pct: >
+            {% set r = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
+            {% set f = (r / 100) if 50 <= r <= 100 else 1.0 %}
+            {{ ((1 / f - 1) * 100) | round(1) }}
 
 rest:
   - resource_template: "http://{{ states('input_text.zendure_2400_ac_ip_adres') }}/properties/report"

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1547,6 +1547,23 @@ actions:
             value_template: >-
               {{ states('sensor.dynamic_spread_indication_dsc') | float >=
               states('input_number.dynamic_setting_minimal_spread') | float }}
+          - alias: >-
+              RTE break-even: avg. expensive period x RTE must exceed the avg.
+              cheap purchase price (blocks charging on a loss-making cycle)
+            condition: template
+            value_template: >-
+              {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+              {% set duurste = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
+              {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+              {% set duur = duurste | list %}
+              {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamic_rte_effective') | float(1.0) %}
+              {{ (avg_duur * factor - avg_goedkoop) > 0 }}
+              {% else %}
+              true
+              {% endif %}
           - condition: state
             entity_id: input_boolean.dynamic_charging_running
             state:
@@ -1666,6 +1683,22 @@ actions:
             value_template: >-
               {{ states('sensor.dynamic_spread_indication') | float >=
               states('input_number.dynamic_setting_minimal_spread') | float }}
+          - alias: >-
+              RTE break-even: avg. expensive period x RTE must exceed the avg.
+              cheap purchase price (blocks charging on a loss-making cycle)
+            condition: template
+            value_template: >-
+              {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+              {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+              {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
+              {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamic_rte_effective') | float(1.0) %}
+              {{ (avg_duur * factor - avg_goedkoop) > 0 }}
+              {% else %}
+              true
+              {% endif %}
           - condition: state
             entity_id: input_boolean.dynamic_charging_running
             state:

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -685,6 +685,18 @@ template:
             {% else %}
               n.v.t.
             {% endif %}
+          netto_spread: >
+            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+            {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamic_rte_effective') | float(1.0) %}
+              {{ ((avg_duur * factor - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% else %}
+              0
+            {% endif %}
 
       - name: "Dynamic Spread Indication DSC"
         unique_id: dynamic_spread_indication_dsc
@@ -761,6 +773,19 @@ template:
               €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
             {% else %}
               n.v.t.
+            {% endif %}
+          netto_spread: >
+            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+            {% set duurste = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+            {% set duur = duurste | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+              {% set factor = states('sensor.dynamic_rte_effective') | float(1.0) %}
+              {{ ((avg_duur * factor - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
+            {% else %}
+              0
             {% endif %}
 
       - name: "Dynamic Spread Indication Tomorrow"
@@ -1458,6 +1483,24 @@ template:
           {% else %}
             0
           {% endif %}
+
+      - name: "Dynamic RTE Effective"
+        unique_id: dynamic_rte_effective
+        icon: mdi:battery-sync
+        state: >
+          {% set r = states('sensor.zendure_rte_total') | float(0) %}
+          {{ ((r / 100) if 50 <= r <= 100 else 1.0) | round(4) }}
+        attributes:
+          rte_total_percentage: >
+            {% set r = states('sensor.zendure_rte_total') | float(0) %}
+            {{ r }}
+          correction_active: >
+            {% set r = states('sensor.zendure_rte_total') | float(0) %}
+            {{ 50 <= r <= 100 }}
+          break_even_spread_pct: >
+            {% set r = states('sensor.zendure_rte_total') | float(0) %}
+            {% set f = (r / 100) if 50 <= r <= 100 else 1.0 %}
+            {{ ((1 / f - 1) * 100) | round(1) }}
 
 rest:
   - resource_template: "http://{{ states('input_text.zendure_setting_ip_address') }}/properties/report"


### PR DESCRIPTION
## Summary

This adds a round-trip efficiency (RTE) check to the dynamic trading modes so the battery will not charge for a trade that cannot cover its own conversion losses. Today the spread gate only looks at the gross price difference and ignores the fact that you get back roughly 85% of what you store, so it can green-light cycles that actually lose money. The change leaves the `minimale_spread` / `minimal_spread` setting exactly as it is and adds a hard floor on top: a charge only goes through if the average price in the expensive window, multiplied by the measured RTE, still beats the average price in the cheap window. It is always on, needs no new setting, and falls back to the old gross behavior whenever RTE data is not trustworthy yet (fresh install, right after a restart), so trading never freezes. The only trades it blocks are the ones that were quietly running at a loss, so a well-tuned setup will not see any difference.

## Why

For a buy-then-sell cycle to be profitable the sell price has to clear the conversion loss: `avg_expensive * RTE > avg_cheap`. In gross-spread terms the break-even is `(1/RTE - 1) * 100`, for example about 17.6% at 85% RTE and 11.1% at 90%. The current gate compares only the gross spread against a single user threshold, so any setup with the spread threshold set below its break-even is authorizing loss-making cycles without knowing it.

## What changed

Packages (`zendure_gielz1986_nl.yaml`, `zendure_gielz1986_global.yaml`):
- New helper sensor `dynamisch_rte_effectief` / `dynamic_rte_effective`: a guarded RTE factor, `RTE/100` when RTE is between 50 and 100%, otherwise `1.0` (no correction). Exposes `correctie_actief` / `correction_active` and `break_even_spread_pct` attributes.
- New `netto_spread` attribute on the two gated spread sensors so the efficiency-corrected spread is visible on dashboards.

Automations (`automation_nl.yaml`, `automation_global.yaml`):
- A break-even floor added as one extra AND condition on the two charge gates only (NOM/DSC charge and the trading charge). It is the sign-safe form `avg_duur * factor - avg_goedkoop > 0`, computed over the same windows as the gross spread.
- The existing gross `spread >= minimal_spread` gate is untouched, and all discharge gates are untouched.

## Guards
- RTE is measured at the battery pack terminals (`outputPackPower` / `packInputPower`), so it is source-agnostic: solar charging and self-consumption affect both sides of the export/import ratio and cancel out. It is a true round-trip efficiency, not understated by PV.
- `RTE = 0` on a fresh install or after a restart maps to factor `1.0`, so the floor degrades to the existing gross behavior and never blocks all trading.
- The floor uses a subtraction, not a ratio, so it stays correct under negative day-ahead prices.
- When price-window data is missing the floor returns true (fail open).
