### PR TITLE
Next release

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260627)
+description: Configuratie Versie (v20260702)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1624,7 +1624,7 @@ actions:
                 trigger: template
                 value_template: >
                   {{ states('sensor.zendure_2400_ac_laadpercentage') | float(0)
-                  ==
+                  >=
                      states('sensor.zendure_2400_ac_maximale_laadpercentage') | float(0) }}
                 for:
                   hours: 0
@@ -1744,7 +1744,7 @@ actions:
                 trigger: template
                 value_template: >
                   {{ states('sensor.zendure_2400_ac_laadpercentage') | float(0)
-                  ==
+                  >=
                      states('sensor.zendure_2400_ac_maximale_laadpercentage') | float(0) }}
                 for:
                   hours: 0

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260620)
+description: Configuratie Versie (v20260623)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1624,6 +1624,11 @@ actions:
                 entity_id:
                   - sensor.dynamisch_spread_indicatie_nom
             continue_on_timeout: false
+          - action: input_boolean.turn_off
+            target:
+              entity_id:
+                - input_boolean.dynamisch_laden_loopt
+            data: {}
           - action: rest_command.zendure_stop_met_alles
             data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
@@ -1632,11 +1637,6 @@ actions:
             data: {}
             target:
               entity_id: input_boolean.dynamisch_recent_geladen
-          - action: input_boolean.turn_off
-            target:
-              entity_id:
-                - input_boolean.dynamisch_laden_loopt
-            data: {}
           - action: logbook.log
             data:
               message: 💲Dynamisch NOM goedkoop laden voltooid  —
@@ -1744,6 +1744,11 @@ actions:
                 entity_id:
                   - sensor.dynamisch_spread_indicatie
             continue_on_timeout: false
+          - action: input_boolean.turn_off
+            target:
+              entity_id:
+                - input_boolean.dynamisch_laden_loopt
+            data: {}
           - action: rest_command.zendure_stop_met_alles
             data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
@@ -1751,11 +1756,6 @@ actions:
             data: {}
             target:
               entity_id: input_boolean.dynamisch_recent_geladen
-          - action: input_boolean.turn_off
-            target:
-              entity_id:
-                - input_boolean.dynamisch_laden_loopt
-            data: {}
           - action: logbook.log
             data:
               message: 💲Dynamisch goedkoop laden voltooid  —
@@ -1858,14 +1858,14 @@ actions:
                 entity_id:
                   - sensor.dynamisch_spread_indicatie
             continue_on_timeout: false
-          - action: rest_command.zendure_stop_met_alles
-            data:
-              sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
           - action: input_boolean.turn_off
             target:
               entity_id:
                 - input_boolean.dynamisch_ontladen_loopt
             data: {}
+          - action: rest_command.zendure_stop_met_alles
+            data:
+              sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
           - action: logbook.log
             data:
               message: 💲Dynamisch duur ontladen voltooid  —

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260702)
+description: Configuratie Versie (v20260703)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -860,6 +860,38 @@ actions:
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: PV export aanpassen
+      - conditions:
+          - condition: state
+            entity_id: sensor.zendure_2400_ac_offgrid_modus
+            state:
+              - Eco
+              - Normaal
+          - condition: numeric_state
+            entity_id: sensor.zendure_2400_ac_vermogen_offgrid_stopcontact_1
+            above: 0
+          - condition: state
+            entity_id: sensor.zendure_2400_ac_opslagmodus
+            state:
+              - Opslaan in RAM
+          - condition: template
+            value_template: >-
+              {{ states('sensor.zendure_2400_ac_vermogen_offgrid_stopcontact_1')
+              | float(0) ==
+                 (states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) | abs) }}
+          - condition: state
+            entity_id: sensor.zendure_2400_ac_modus
+            state:
+              - Ontladen
+        sequence:
+          - action: rest_command.zendure_standby
+            data:
+              sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
+          - action: logbook.log
+            data:
+              message: ⚠️Activeer AC doorvoer voor offgrid —
+              entity_id: input_select.zendure_2400_ac_modus_selecteren
+              name: " "
+        alias: Activeer AC doorvoer voor offgrid
   - alias: NOM Aansturing
     choose:
       - conditions:

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260703)
+description: Configuratie Versie (v20260712)
 triggers:
   - seconds: /5
     id: aansturing_trigger

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260623)
+description: Configuratie Versie (v20260627)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -153,6 +153,18 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
         alias: Dynamisch Handelen
+      - conditions:
+          - condition: trigger
+            id: modus_trigger
+          - condition: state
+            entity_id: input_select.zendure_2400_ac_modus_selecteren
+            state:
+              - Dynamisch Handelen + NOM
+        sequence:
+          - action: rest_command.zendure_stop_met_alles
+            data:
+              sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
+        alias: Dynamisch Handelen + NOM
       - conditions:
           - condition: trigger
             id: modus_trigger
@@ -315,6 +327,10 @@ actions:
                 entity_id: input_select.zendure_2400_ac_modus_selecteren
                 state:
                   - Dynamisch NOM (Duur)
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state:
+                  - Dynamisch Handelen + NOM
           - condition: or
             conditions:
               - condition: sun

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -2833,10 +2833,18 @@ views:
                 color: '#01a180'
                 tap_action:
                   action: more-info
+            visibility:
+              - condition: state
+                entity: input_boolean.pv_tonen_op_dashboard
+                state: 'on'
           - type: entities
             entities:
               - entity: input_boolean.zendure_2400_ac_pv_export_uitgeschakeld
                 name: PV Export Uitgeschakeld
+            visibility:
+              - condition: state
+                entity: input_boolean.pv_tonen_op_dashboard
+                state: 'on'
           - type: heading
             icon: ''
             heading: Configuratie (Optioneel)
@@ -2871,6 +2879,10 @@ views:
             heading: Configuratie (Dynamisch)
             heading_style: title
             badges: []
+            visibility:
+              - condition: state
+                entity: input_boolean.dynamisch_tonen_op_dashboard
+                state: 'on'
           - type: markdown
             content: >-
               <ha-alert alert-type="info">Helptekst</ha-alert>Heb je een
@@ -2886,6 +2898,9 @@ views:
               - condition: state
                 entity: input_boolean.help_tonen_op_dashboard
                 state: 'on'
+              - condition: state
+                entity: input_boolean.dynamisch_tonen_op_dashboard
+                state: 'on'
           - type: entities
             entities:
               - entity: input_text.dynamisch_nordpool_sensor
@@ -2895,6 +2910,10 @@ views:
                 name: Minimale Spread
               - entity: input_boolean.dynamisch_15_minuten
                 name: 15 Minuten Tarieven Actief
+            visibility:
+              - condition: state
+                entity: input_boolean.dynamisch_tonen_op_dashboard
+                state: 'on'
           - type: heading
             icon: ''
             heading_style: title

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -438,7 +438,7 @@ views:
               color_threshold: true
             cache: false
             stacked: true
-            update_interval: 1sec
+            update_interval: 5sec
             header:
               show: true
               show_states: true
@@ -449,10 +449,10 @@ views:
                 name: Batterij
                 group_by:
                   func: avg
-                  duration: 1sec
+                  duration: 5sec
                 type: area
                 transform: return -x;
-                offset: '-1s'
+                offset: '-5s'
                 stroke_width: 2
                 opacity: 0.35
                 extend_to: now
@@ -496,10 +496,10 @@ views:
                   offset_in_name: false
               - entity: sensor.p1_nom_doel
                 name: Energiemeter
-                offset: '-1s'
+                offset: '-5s'
                 group_by:
                   func: avg
-                  duration: 1sec
+                  duration: 5sec
                 type: area
                 stroke_width: 0
                 opacity: 0.3

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -158,7 +158,7 @@ views:
                   in_header: false
                   in_legend: true
               - entity: sensor.p1_nom_doel
-                name: P1 (NOM Doel)
+                name: Energiemeter
                 statistics:
                   period: 5minute
                   type: mean
@@ -173,7 +173,7 @@ views:
                 show:
                   in_brush: true
                   in_header: false
-                  in_legend: false
+                  in_legend: true
               - entity: sensor.zendure_2400_ac_laadpercentage
                 name: Laadpercentage
                 statistics:
@@ -242,7 +242,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "Laadpercentage" || seriesName === "P1 (NOM Doel)") return "";
+                    if(seriesName === "Laadpercentage" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:
@@ -337,7 +337,7 @@ views:
                   in_header: false
                   in_legend: true
               - entity: sensor.p1_nom_doel
-                name: P1 (NOM Doel)
+                name: Energiemeter
                 statistics:
                   period: 5minute
                   type: mean
@@ -352,7 +352,7 @@ views:
                 show:
                   in_brush: true
                   in_header: false
-                  in_legend: false
+                  in_legend: true
               - entity: sensor.zendure_2400_ac_laadpercentage
                 name: Laadpercentage
                 statistics:
@@ -421,7 +421,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "Laadpercentage" || seriesName === "P1 (NOM Doel)") return "";
+                    if(seriesName === "Laadpercentage" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:
@@ -438,7 +438,7 @@ views:
               color_threshold: true
             cache: false
             stacked: true
-            update_interval: 5sec
+            update_interval: 1sec
             header:
               show: true
               show_states: true
@@ -449,10 +449,10 @@ views:
                 name: Batterij
                 group_by:
                   func: avg
-                  duration: 5sec
+                  duration: 1sec
                 type: area
                 transform: return -x;
-                offset: '-5s'
+                offset: '-1s'
                 stroke_width: 2
                 opacity: 0.35
                 extend_to: now
@@ -495,11 +495,11 @@ views:
                   in_legend: true
                   offset_in_name: false
               - entity: sensor.p1_nom_doel
-                name: P1 (NOM Doel)
-                offset: '-5s'
+                name: Energiemeter
+                offset: '-1s'
                 group_by:
                   func: avg
-                  duration: 5sec
+                  duration: 1sec
                 type: area
                 stroke_width: 0
                 opacity: 0.3
@@ -509,35 +509,8 @@ views:
                 yaxis_id: energy
                 show:
                   in_header: false
-                  in_legend: false
-              - entity: input_number.zendure_2400_ac_ontladen_starten_bij
-                name: Start ontladen
-                type: line
-                stroke_width: 2
-                color: var(--accent-color)
-                opacity: 1
-                stroke_dash: 2
-                curve: stepline
-                extend_to: now
-                float_precision: 0
-                yaxis_id: energy
-                show:
-                  hidden_by_default: true
-                  in_header: false
-              - entity: input_number.zendure_2400_ac_opladen_starten_bij
-                name: Start opladen
-                type: line
-                stroke_width: 2
-                color: var(--accent-color)
-                opacity: 1
-                stroke_dash: 2
-                curve: stepline
-                extend_to: now
-                float_precision: 0
-                yaxis_id: energy
-                show:
-                  hidden_by_default: true
-                  in_header: false
+                  in_legend: true
+                  offset_in_name: false
             apex_config:
               toolbar:
                 show: true
@@ -587,7 +560,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "Leeg" || seriesName === "P1 (NOM Doel) (-5s)") return "";
+                    if(seriesName === "Leeg" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1145,9 +1145,16 @@ views:
                   in_header: false
                   legend_value: false
                   extremas: false
-                data_generator: |
+                data_generator: >
                   const data = entity.attributes.raw_today;
+
                   if (!data) return [];
+
+
+                  const correctie =
+                  parseFloat(hass.states['input_number.dynamisch_export_correctie'].state
+                  || 0);
+
 
                   return data.map((item, index) => {
                     const tijdStart = new Date(item.start).getTime();
@@ -1158,7 +1165,12 @@ views:
                                           : 3600000);
                     const tijdEind = tijdStart + duration;
 
-                    const prijs = item.value;
+                    let prijs = item.value;
+
+                    if (item.duur === "ja") {
+                      prijs = prijs - correctie;
+                    }
+
                     const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
 
                     // Standaardkleur: #e0e0e3
@@ -1221,117 +1233,125 @@ views:
                 after: '13:30:00'
                 before: '24:00:00'
             badges: []
-          - type: horizontal-stack
-            cards:
-              - type: custom:apexcharts-card
-                update_interval: 1sec
-                graph_span: 24h
-                apex_config:
-                  noData:
-                    text: Vanaf 14:00 zijn de prijzen van morgen bekend.
-                  markers:
-                    size: 0
-                    hover:
-                      size: 0
-                  plotOptions:
-                    bar:
-                      columnWidth: 90%
-                  tooltip:
-                    enabledOnSeries:
-                      - 0
-                    followCursor: true
-                    shared: true
-                    intersect: false
-                    enabled: true
-                    x:
-                      format: HH:mm
-                      show: false
-                    'y':
-                      formatter: |
-                        EVAL: (val) => `${val.toFixed(3)} €/kWh`
-                  grid:
-                    show: true
-                    borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
-                    strokeDashArray: 0
-                    padding:
-                      top: -10
-                  chart:
-                    height: 150px
-                    stacked: true
-                    stackOnlyBar: true
-                  yaxis:
-                    - title:
-                        text: ''
-                      decimalsInFloat: 2
-                      forceNiceScale: true
-                      labels:
-                        style:
-                          colors: >-
-                            color-mix(in srgb, var(--primary-text-color) 75%,
-                            transparent)
-                  xaxis:
-                    labels:
-                      show: false
-                    axisTicks:
-                      show: false
-                    axisBorder:
-                      color: >-
-                        color-mix(in srgb, var(--divider-color) 50%,
+          - type: custom:apexcharts-card
+            update_interval: 1sec
+            graph_span: 24h
+            apex_config:
+              noData:
+                text: Vanaf 14:00 zijn de prijzen van morgen bekend.
+              markers:
+                size: 0
+                hover:
+                  size: 0
+              plotOptions:
+                bar:
+                  columnWidth: 90%
+              tooltip:
+                enabledOnSeries:
+                  - 0
+                followCursor: true
+                shared: true
+                intersect: false
+                enabled: true
+                x:
+                  format: HH:mm
+                  show: false
+                'y':
+                  formatter: |
+                    EVAL: (val) => `${val.toFixed(3)} €/kWh`
+              grid:
+                show: true
+                borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
+                strokeDashArray: 0
+                padding:
+                  top: -10
+              chart:
+                height: 150px
+                stacked: true
+                stackOnlyBar: true
+              yaxis:
+                - title:
+                    text: ''
+                  decimalsInFloat: 2
+                  forceNiceScale: true
+                  labels:
+                    style:
+                      colors: >-
+                        color-mix(in srgb, var(--primary-text-color) 75%,
                         transparent)
-                  legend:
-                    show: false
-                span:
-                  start: day
-                  offset: +1d
-                series:
-                  - entity: sensor.dynamisch_goedkoopste_periode
-                    name: Morgen
-                    type: column
-                    float_precision: 3
-                    color: '#e0e0e3'
-                    show:
-                      in_header: false
-                      legend_value: false
-                    data_generator: |
-                      const data = entity.attributes.raw_tomorrow;
-                      if (!data) return [];
+              xaxis:
+                labels:
+                  show: false
+                axisTicks:
+                  show: false
+                axisBorder:
+                  color: color-mix(in srgb, var(--divider-color) 50%, transparent)
+              legend:
+                show: false
+            span:
+              start: day
+              offset: +1d
+            series:
+              - entity: sensor.dynamisch_goedkoopste_periode
+                name: Morgen
+                type: column
+                float_precision: 3
+                color: '#e0e0e3'
+                show:
+                  in_header: false
+                  legend_value: false
+                data_generator: >
+                  const data = entity.attributes.raw_tomorrow;
 
-                      return data.map((item, index) => {
-                        const tijdStart = new Date(item.start).getTime();
-                        const duration = item.duration
-                                          ? item.duration * 1000
-                                          : (data[index + 1]
-                                              ? new Date(data[index + 1].start).getTime() - tijdStart
-                                              : 3600000);
-                        const tijdEind = tijdStart + duration;
-
-                        const prijs = item.value;
-                        const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
-
-                        // Standaardkleur: #e0e0e3
-                        let kleur = "rgba(224,224,227,1)";
+                  if (!data) return [];
 
 
-                        if (item.goedkoop === "ja") {
-                          kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
-                        }
-                        else if (item.duur === "ja") {
-                          kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
-                        }
-                        else {
-                          kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
-                        }
+                  const correctie =
+                  parseFloat(hass.states['input_number.dynamisch_export_correctie'].state
+                  || 0);
 
-                        return {
-                          x: tijdStart,
-                          y: prijs,
-                          fillColor: kleur
-                        };
-                      });
-                visibility:
-                  - condition: time
-                    after: '13:30:00'
-                    before: '24:00:00'
+
+                  return data.map((item, index) => {
+                    const tijdStart = new Date(item.start).getTime();
+                    const duration = item.duration
+                                      ? item.duration * 1000
+                                      : (data[index + 1]
+                                          ? new Date(data[index + 1].start).getTime() - tijdStart
+                                          : 3600000);
+                    const tijdEind = tijdStart + duration;
+
+                    let prijs = item.value;
+
+                    if (item.duur === "ja") {
+                      prijs = prijs - correctie;
+                    }
+
+                    const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
+
+                    // Standaardkleur: #e0e0e3
+                    let kleur = "rgba(224,224,227,1)";
+
+
+                    if (item.goedkoop === "ja") {
+                      kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
+                    }
+                    else if (item.duur === "ja") {
+                      kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
+                    }
+                    else {
+                      kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
+                    }
+
+                    return {
+                      x: tijdStart,
+                      y: prijs,
+                      fillColor: kleur
+                    };
+                  });
+            visibility:
+              - condition: time
+                after: '13:30:00'
+                before: '24:00:00'
           - type: horizontal-stack
             cards:
               - type: tile
@@ -2869,6 +2889,8 @@ views:
           - type: entities
             entities:
               - entity: input_text.dynamisch_nordpool_sensor
+              - entity: input_number.dynamisch_export_correctie
+                name: Export Correctie
               - entity: input_number.dynamisch_minimale_spread
                 name: Minimale Spread
               - entity: input_boolean.dynamisch_15_minuten

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260702"
+        state: "v20260703"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -101,6 +101,15 @@ input_text:
     mode: text
 
 input_number:
+  dynamisch_export_correctie:
+    name: Dynamisch Export Correctie
+    icon: mdi:cash
+    min: 0
+    max: 0.20
+    step: 0.001
+    mode: box
+    unit_of_measurement: "€/kWh"
+
   zendure_2400_ac_max_oplaadvermogen:
     name: Zendure 2400 AC Max. Oplaadvermogen
     icon: mdi:format-vertical-align-top
@@ -618,11 +627,12 @@ template:
         unit_of_measurement: "%"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+          {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
           {% set duur = uren | selectattr('duur','equalto','ja') | list %}
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
-            {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+            {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correctie %}
             {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
           {% else %}
             0
@@ -654,10 +664,11 @@ template:
             ]
           duurste_periode: >
             {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','ja') | sort(attribute='start') | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value - correctie) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
@@ -671,17 +682,22 @@ template:
             {% endif %}
           gemiddelde_duur: >
             {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','ja') | list %}
             {% if duur | count > 0 %}
-              €{{ '%.4f' % (duur | map(attribute='value') | sum / duur | count) }}
+              €{{ '%.4f' % ((duur | map(attribute='value') | sum / duur | count) - correctie) }}
             {% else %}
               n.v.t.
             {% endif %}
           verschil_waarde: >
-            {% set g = state_attr('sensor.dynamisch_spread_indicatie','gemiddelde_goedkoop') %}
-            {% set d = state_attr('sensor.dynamisch_spread_indicatie','gemiddelde_duur') %}
-            {% if g not in ['n.v.t.', None] and d not in ['n.v.t.', None] %}
-              €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
+            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+            {% set duur = uren | selectattr('duur','equalto','ja') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correctie %}
+              €{{ '%.4f' % (avg_duur - avg_goedkoop) }}
             {% else %}
               n.v.t.
             {% endif %}
@@ -769,11 +785,12 @@ template:
         unit_of_measurement: "%"
         state: >
           {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
+          {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
           {% set duur = uren | selectattr('duur','equalto','ja') | list %}
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
-            {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+            {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correctie %}
             {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
           {% else %}
             0
@@ -805,10 +822,11 @@ template:
             ]
           duurste_periode: >
             {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','ja') | sort(attribute='start') | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value - correctie) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
@@ -822,17 +840,22 @@ template:
             {% endif %}
           gemiddelde_duur: >
             {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','ja') | list %}
             {% if duur | count > 0 %}
-              €{{ '%.4f' % (duur | map(attribute='value') | sum / duur | count) }}
+              €{{ '%.4f' % ((duur | map(attribute='value') | sum / duur | count) - correctie) }}
             {% else %}
               n.v.t.
             {% endif %}
           verschil_waarde: >
-            {% set g = state_attr('sensor.dynamisch_spread_indicatie_morgen','gemiddelde_goedkoop') %}
-            {% set d = state_attr('sensor.dynamisch_spread_indicatie_morgen','gemiddelde_duur') %}
-            {% if g not in ['n.v.t.', None] and d not in ['n.v.t.', None] %}
-              €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
+            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
+            {% set correctie = states('input_number.dynamisch_export_correctie') | float(0) %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+            {% set duur = uren | selectattr('duur','equalto','ja') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correctie %}
+              €{{ '%.4f' % (avg_duur - avg_goedkoop) }}
             {% else %}
               n.v.t.
             {% endif %}

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260703"
+        state: "v20260712"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -365,7 +365,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260627"
+        state: "v20260702"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -365,7 +365,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260620"
+        state: "v20260627"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260627)
+description: Configuration Version (v20260702)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1600,7 +1600,7 @@ actions:
                 trigger: template
                 value_template: >
                   {{ states('sensor.zendure_total_state_of_charge') | float(0)
-                  ==
+                  >=
                      states('sensor.zendure_maximum_state_of_charge') | float(0) }}
                 for:
                   hours: 0
@@ -1719,7 +1719,7 @@ actions:
                 trigger: template
                 value_template: >
                   {{ states('sensor.zendure_total_state_of_charge') | float(0)
-                  ==
+                  >=
                      states('sensor.zendure_maximum_state_of_charge') | float(0) }}
                 for:
                   hours: 0

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260703)
+description: Configuration Version (v20260712)
 triggers:
   - seconds: /5
     id: aansturing_trigger

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260702)
+description: Configuration Version (v20260703)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -849,6 +849,37 @@ actions:
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: adjust PV export
+      - conditions:
+          - condition: state
+            entity_id: sensor.zendure_offgrid_mode
+            state:
+              - Eco
+              - Normal
+          - condition: numeric_state
+            entity_id: sensor.zendure_power_offgrid_outlet_1
+            above: 0
+          - condition: state
+            entity_id: sensor.zendure_storage_mode
+            state:
+              - RAM Memory
+          - condition: template
+            value_template: |-
+              {{ states('sensor.zendure_power_offgrid_outlet_1') | float(0) ==
+                 (states('sensor.zendure_power') | float(0) | abs) }}
+          - condition: state
+            entity_id: sensor.zendure_charging_mode
+            state:
+              - Discharging
+        sequence:
+          - action: rest_command.zendure_full_standby
+            data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
+          - action: logbook.log
+            data:
+              message: ⚠️Activate AC passthrough for offgrid —
+              entity_id: input_select.zendure_operation_mode
+              name: " "
+        alias: Activate AC passthrough for offgrid
   - alias: Smart Matching Control
     choose:
       - conditions:

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260623)
+description: Configuration Version (v20260627)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -154,6 +154,18 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
         alias: Dynamic Trading
+      - conditions:
+          - condition: trigger
+            id: modus_trigger
+          - condition: state
+            entity_id: input_select.zendure_operation_mode
+            state:
+              - Dynamic Trading + Smart Matching
+        sequence:
+          - action: rest_command.zendure_stop_with_everything
+            data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
+        alias: Dynamic Trading + Smart Matching
       - conditions:
           - condition: trigger
             id: modus_trigger
@@ -316,6 +328,10 @@ actions:
                 entity_id: input_select.zendure_operation_mode
                 state:
                   - Dynamic Smart Matching (Expensive)
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state:
+                  - Dynamic Trading + Smart Matching
           - condition: or
             conditions:
               - condition: sun

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260620)
+description: Configuration Version (v20260623)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1600,6 +1600,11 @@ actions:
                 entity_id:
                   - sensor.dynamic_spread_indication_dsc
             continue_on_timeout: false
+          - action: input_boolean.turn_off
+            target:
+              entity_id:
+                - input_boolean.dynamic_charging_running
+            data: {}
           - action: rest_command.zendure_stop_with_everything
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
@@ -1607,11 +1612,6 @@ actions:
             data: {}
             target:
               entity_id: input_boolean.dynamic_recently_charged
-          - action: input_boolean.turn_off
-            target:
-              entity_id:
-                - input_boolean.dynamic_charging_running
-            data: {}
           - action: logbook.log
             data:
               message: 💲Dynamic Smart Matching cheap charging complete   —
@@ -1719,6 +1719,11 @@ actions:
                 entity_id:
                   - sensor.dynamic_spread_indication
             continue_on_timeout: false
+          - action: input_boolean.turn_off
+            target:
+              entity_id:
+                - input_boolean.dynamic_charging_running
+            data: {}
           - action: rest_command.zendure_stop_with_everything
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
@@ -1726,11 +1731,6 @@ actions:
             data: {}
             target:
               entity_id: input_boolean.dynamic_recently_charged
-          - action: input_boolean.turn_off
-            target:
-              entity_id:
-                - input_boolean.dynamic_charging_running
-            data: {}
           - action: logbook.log
             data:
               message: 💲Dynamic cheap charging complete  —
@@ -1833,14 +1833,14 @@ actions:
                 entity_id:
                   - sensor.dynamic_spread_indication
             continue_on_timeout: false
-          - action: rest_command.zendure_stop_with_everything
-            data:
-              sn: "{{ states('sensor.zendure_serial_number') }}"
           - action: input_boolean.turn_off
             target:
               entity_id:
                 - input_boolean.dynamic_discharging_running
             data: {}
+          - action: rest_command.zendure_stop_with_everything
+            data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
           - action: logbook.log
             data:
               message: 💲Dynamic expensive discharge complete  —

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1141,9 +1141,16 @@ views:
                   in_header: false
                   legend_value: false
                   extremas: false
-                data_generator: |
+                data_generator: >
                   const data = entity.attributes.raw_today;
+
                   if (!data) return [];
+
+
+                  const correction =
+                  parseFloat(hass.states['input_number.dynamic_export_correction'].state
+                  || 0);
+
 
                   return data.map((item, index) => {
                     const tijdStart = new Date(item.start).getTime();
@@ -1154,7 +1161,12 @@ views:
                                           : 3600000);
                     const tijdEind = tijdStart + duration;
 
-                    const prijs = item.value;
+                    let prijs = item.value;
+
+                    if (item.duur === "Yes") {
+                      prijs = prijs - correction;
+                    }
+
                     const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
 
                     // Standaardkleur: #e0e0e3
@@ -1288,9 +1300,16 @@ views:
                     show:
                       in_header: false
                       legend_value: false
-                    data_generator: |
+                    data_generator: >
                       const data = entity.attributes.raw_tomorrow;
+
                       if (!data) return [];
+
+
+                      const correction =
+                      parseFloat(hass.states['input_number.dynamic_export_correction'].state
+                      || 0);
+
 
                       return data.map((item, index) => {
                         const tijdStart = new Date(item.start).getTime();
@@ -1301,7 +1320,12 @@ views:
                                               : 3600000);
                         const tijdEind = tijdStart + duration;
 
-                        const prijs = item.value;
+                        let prijs = item.value;
+
+                        if (item.duur === "Yes") {
+                          prijs = prijs - correction;
+                        }
+
                         const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
 
                         // Standaardkleur: #e0e0e3
@@ -2860,6 +2884,8 @@ views:
           - type: entities
             entities:
               - entity: input_text.dynamic_setting_nordpool_sensor
+              - entity: input_number.dynamic_export_correction
+                name: Export Correction
               - entity: input_number.dynamic_setting_minimal_spread
                 name: Minimal Spread
               - entity: input_boolean.dynamic_setting_15_minute_interval

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -2825,10 +2825,18 @@ views:
                 color: '#01a180'
                 tap_action:
                   action: more-info
+            visibility:
+              - condition: state
+                entity: input_boolean.dashboard_setting_show_pv
+                state: 'on'
           - type: entities
             entities:
               - entity: input_boolean.zendure_setting_pv_export_disabled
                 name: PV Export Disabled
+            visibility:
+              - condition: state
+                entity: input_boolean.dashboard_setting_show_pv
+                state: 'on'
           - type: heading
             icon: ''
             heading: Configuration (Optional)
@@ -2864,6 +2872,10 @@ views:
             heading: Configuration (Dynamic)
             heading_style: title
             badges: []
+            visibility:
+              - condition: state
+                entity: input_boolean.dashboard_setting_show_dynamic
+                state: 'on'
           - type: markdown
             content: >-
               <ha-alert alert-type="info">Help text</ha-alert>If you have a
@@ -2880,6 +2892,9 @@ views:
               - condition: state
                 entity: input_boolean.dashboard_setting_show_help
                 state: 'on'
+              - condition: state
+                entity: input_boolean.dashboard_setting_show_dynamic
+                state: 'on'
             text_only: true
           - type: entities
             entities:
@@ -2890,6 +2905,10 @@ views:
                 name: Minimal Spread
               - entity: input_boolean.dynamic_setting_15_minute_interval
                 name: 15 Minute Interval
+            visibility:
+              - condition: state
+                entity: input_boolean.dashboard_setting_show_dynamic
+                state: 'on'
           - type: heading
             icon: ''
             heading_style: title

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -173,7 +173,7 @@ views:
                 show:
                   in_brush: true
                   in_header: false
-                  in_legend: false
+                  in_legend: true
               - entity: sensor.zendure_total_state_of_charge
                 name: State Of Charge
                 statistics:
@@ -242,7 +242,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "State Of Charge" || seriesName === "Home Energy Meter") return "";
+                    if(seriesName === "State Of Charge" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:
@@ -352,7 +352,7 @@ views:
                 show:
                   in_brush: true
                   in_header: false
-                  in_legend: false
+                  in_legend: true
               - entity: sensor.zendure_total_state_of_charge
                 name: State Of Charge
                 statistics:
@@ -421,7 +421,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "State Of Charge" || seriesName === "Home Energy Meter") return "";
+                    if(seriesName === "State Of Charge" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:
@@ -449,10 +449,10 @@ views:
                 name: Battery
                 group_by:
                   func: avg
-                  duration: 5sec
+                  duration: 1sec
                 type: area
                 transform: return -x;
-                offset: '-5s'
+                offset: '-1s'
                 stroke_width: 2
                 opacity: 0.35
                 extend_to: now
@@ -496,10 +496,10 @@ views:
                   offset_in_name: false
               - entity: sensor.home_energy_meter_target
                 name: Home Energy Meter
-                offset: '-5s'
+                offset: '-1s'
                 group_by:
                   func: avg
-                  duration: 5sec
+                  duration: 1sec
                 type: area
                 stroke_width: 0
                 opacity: 0.3
@@ -509,35 +509,8 @@ views:
                 yaxis_id: energy
                 show:
                   in_header: false
-                  in_legend: false
-              - entity: input_number.zendure_setting_start_discharging_at
-                name: Start discharging
-                type: line
-                stroke_width: 2
-                color: var(--accent-color)
-                opacity: 1
-                stroke_dash: 2
-                curve: stepline
-                extend_to: now
-                float_precision: 0
-                yaxis_id: energy
-                show:
-                  hidden_by_default: true
-                  in_header: false
-              - entity: input_number.zendure_setting_start_charging_at
-                name: Start charging
-                type: line
-                stroke_width: 2
-                color: var(--accent-color)
-                opacity: 1
-                stroke_dash: 2
-                curve: stepline
-                extend_to: now
-                float_precision: 0
-                yaxis_id: energy
-                show:
-                  hidden_by_default: true
-                  in_header: false
+                  in_legend: true
+                  offset_in_name: false
             apex_config:
               toolbar:
                 show: true
@@ -587,7 +560,7 @@ views:
                 formatter: |
                   EVAL:function(seriesName, opts) {
                     // filter series die niet in de legenda moeten
-                    if(seriesName === "Leeg" || seriesName === "Home Energy Meter (-5s)") return "";
+                    if(seriesName === "Leeg" || seriesName === "Leeg") return "";
                     return seriesName;
                   }
               markers:

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -449,10 +449,10 @@ views:
                 name: Battery
                 group_by:
                   func: avg
-                  duration: 1sec
+                  duration: 5sec
                 type: area
                 transform: return -x;
-                offset: '-1s'
+                offset: '-5s'
                 stroke_width: 2
                 opacity: 0.35
                 extend_to: now
@@ -496,10 +496,10 @@ views:
                   offset_in_name: false
               - entity: sensor.home_energy_meter_target
                 name: Home Energy Meter
-                offset: '-1s'
+                offset: '-5s'
                 group_by:
                   func: avg
-                  duration: 1sec
+                  duration: 5sec
                 type: area
                 stroke_width: 0
                 opacity: 0.3

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -365,7 +365,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260627"
+        state: "v20260702"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -101,6 +101,15 @@ input_text:
     mode: text
 
 input_number:
+  dynamic_export_correction:
+    name: Dynamic Export Correction
+    icon: mdi:cash
+    min: 0
+    max: 0.20
+    step: 0.001
+    mode: box
+    unit_of_measurement: "€/kWh"
+
   zendure_setting_max_charge_power:
     name: Zendure Maximum Charge Power
     icon: mdi:format-vertical-align-top
@@ -618,11 +627,12 @@ template:
         unit_of_measurement: "%"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+          {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
           {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
-            {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+            {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correction %}
             {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
           {% else %}
             0
@@ -654,10 +664,11 @@ template:
             ]
           highest_price_periods: >
             {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','Yes') | sort(attribute='start') | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value - correction) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
@@ -671,17 +682,22 @@ template:
             {% endif %}
           average_highest_price: >
             {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
             {% if duur | count > 0 %}
-              €{{ '%.4f' % (duur | map(attribute='value') | sum / duur | count) }}
+              €{{ '%.4f' % ((duur | map(attribute='value') | sum / duur | count) - correction) }}
             {% else %}
               n.v.t.
             {% endif %}
           difference_in_value: >
-            {% set g = state_attr('sensor.dynamic_spread_indication','average_lowest_price') %}
-            {% set d = state_attr('sensor.dynamic_spread_indication','average_highest_price') %}
-            {% if g not in ['n.v.t.', None] and d not in ['n.v.t.', None] %}
-              €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
+            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+            {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correction %}
+              €{{ '%.4f' % (avg_duur - avg_goedkoop) }}
             {% else %}
               n.v.t.
             {% endif %}
@@ -769,11 +785,12 @@ template:
         unit_of_measurement: "%"
         state: >
           {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
+          {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
           {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
           {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
           {% if goedkoop | count > 0 and duur | count > 0 %}
             {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
-            {% set avg_duur = duur | map(attribute='value') | sum / duur | count %}
+            {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correction %}
             {{ ((avg_duur - avg_goedkoop) / (avg_goedkoop | abs) * 100) | round(1) }}
           {% else %}
             0
@@ -805,10 +822,11 @@ template:
             ]
           highest_price_periods: >
             {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','Yes') | sort(attribute='start') | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value - correction) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
@@ -822,17 +840,22 @@ template:
             {% endif %}
           average_highest_price: >
             {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
             {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
             {% if duur | count > 0 %}
-              €{{ '%.4f' % (duur | map(attribute='value') | sum / duur | count) }}
+              €{{ '%.4f' % ((duur | map(attribute='value') | sum / duur | count) - correction) }}
             {% else %}
               n.v.t.
             {% endif %}
           difference_in_value: >
-            {% set g = state_attr('sensor.dynamic_spread_indication_tomorrow','average_lowest_price') %}
-            {% set d = state_attr('sensor.dynamic_spread_indication_tomorrow','average_highest_price') %}
-            {% if g not in ['n.v.t.', None] and d not in ['n.v.t.', None] %}
-              €{{ '%.4f' % (d[1:] | float - g[1:] | float) }}
+            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
+            {% set correction = states('input_number.dynamic_export_correction') | float(0) %}
+            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+            {% set duur = uren | selectattr('duur','equalto','Yes') | list %}
+            {% if goedkoop | count > 0 and duur | count > 0 %}
+              {% set avg_goedkoop = goedkoop | map(attribute='value') | sum / goedkoop | count %}
+              {% set avg_duur = (duur | map(attribute='value') | sum / duur | count) - correction %}
+              €{{ '%.4f' % (avg_duur - avg_goedkoop) }}
             {% else %}
               n.v.t.
             {% endif %}

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -365,7 +365,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260620"
+        state: "v20260627"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260703"
+        state: "v20260712"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260702"
+        state: "v20260703"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ homeassistant:
 | `zendure_setting_battery_order` | **e.g. 1;5;3;4;2** – Manually define battery order based on serial numbers and physical stacking. |
 | **Configuration (Dynamic)** | **Information** |
 | `dynamic_setting_nordpool_sensor` | **e.g. sensor.nordpool_kwh_nl_eur_3_09_0** – Your Nordpool (HACS) sensor. |
+| `dynamic_export_correction` | Specify how many cents should be subtracted during export. This value is used in the spread calculation. |
 | `dynamic_setting_minimal_spread` | **e.g. 25%** – Minimum price spread before dynamic charging/discharging activates. |
 | `dynamic_setting_15_minute_interval` | Enable this if you want to use 15-minute intervals. |
 | **Configuration (Dashboard)** | **Information** |

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ homeassistant:
 
 ---
 
-![Preview](Images/Global-Settings-290526.png)  
+<img alt="image" src="https://github.com/user-attachments/assets/c3dc867f-6022-4d12-8926-0e593f411856" />
 *plug-n-play dashboard
 
+<br>
 <br>
 
 | Explanation per configuration item | |

--- a/README.nl.md
+++ b/README.nl.md
@@ -84,6 +84,7 @@ homeassistant:
 | `zendure_2400_ac_batterij_volgorde` | **bijvoorbeeld 1;5;3;4;2** – hiermee bepaal je zelf een afwijkende volgorde van de batterijen. De juiste volgorde bepaal je mede aan de hand van `sensor.zendure_2400_ac_batterij_serienummers` en de sticker op de batterij(en). Op deze manier zullen de batterijtemperaturen en het laadpercentage de juiste volgorde hebben zoals die van de batterij(en) in de stapel. | 
 | **Configuratie (Dynamisch)** |**Informatie**|  
 | `dynamisch_nordpool_sensor` | **bijvoorbeeld `sensor.nordpool_kwh_nl_eur_3_09_0`** – je eigen sensor van Nordpool (HACS) toevoegen. Wanneer je het Dynamisch Nordpool gedeelte in gebruik gaat nemen moet je voor dat je deze in gebruik neemt bij `dynamisch_handmatige_periode` en `dynamisch_handmatige_periode_morgen` even **unknown** weghalen. Hierna zal het dynamisch gedeelte werken. Alles wat in de forecast (morgen) gezet word zal overgenomen worden om 00:00 via de automatisering en verschijnen in vandaag. |  
+| `dynamisch_export_correctie` | Stel het aantal cent in dat tijdens het exporteren wordt afgetrokken. Deze waarde wordt gebruikt in de spreadberekening. |
 | `dynamisch_minimale_spread` | **bijvoorbeeld 25%** - Hiermee geef je aan vanaf hoeveel spread de batterij dynamisch gaat laden en opladen op hoog vermogen.  |  
 | `dynamisch_15_minuten` | Vink dit aan wanneer je gebruik wilt maken van 15 minuten periodes.  |  
 | **Configuratie (Dashboard)** |**Informatie**|  

--- a/README.nl.md
+++ b/README.nl.md
@@ -53,9 +53,10 @@ homeassistant:
 ---
 
 
-![Preview](Images/Instellingen-290526.png) 
+<img  alt="image" src="https://github.com/user-attachments/assets/c395c122-3bc4-4969-99f1-28dbabf89a77" />
 *plug-n-play dashboard
 
+<br>
 <br>
 
 | Uitleg per configuratie item | |  


### PR DESCRIPTION
# English (Global)
⚠️ Please make sure to use the correct language update. ⚠️

## Dashboard
**Energy Graph (Live)**
The 'Start Charging' and 'Start Discharging' legend items have been removed, allowing the hover functionality to work correctly again. You can now filter out the home energy meter, so that only the battery data is displayed.

**Dynamic Charts**
Both charts now take the export correction into account when a period is selected as a discharge/expensive period.

**Dynamic And PV Settings**
These settings are now hidden when PV and/or Dynamic is disabled, keeping the dashboard cleaner and only showing relevant options.

## New features
**Dynamic Export Correction**
Dutch users can now set an export correction between €0.000 and €0.200 per kWh. From 2027, you will no longer be able to receive a tax refund for electricity exported to the grid.

**Offgrid From Grid**
When you are using the offgrid outlet while the battery is connected to the grid. The offgrid outlet (most of the times) draws power from the battery. Now it is forced to draw power directly from the grid instead if possible.

## Bug fixes
**Dynamic Trading + Smart Matching**
When SOC protection was enabled, this mode did not use it, preventing NOM from starting.

**Dynamic Cycle (Charging/Discharging)**
The cycle did not always end correctly, resulting in unintended additional charging/discharging.

**Dynamic Cycle (Charging)**
The cycle did not always end correctly when the maximum state of charge was set below 100%.

<br>
<br>

# Dutch (NL)
⚠️ Zorg ervoor dat je de juiste taalupdate gebruikt. ⚠️

## Dashboard
**Energie Grafiek (live)**
De legenda-items 'Start ontladen' en 'Start opladen' zijn verwijderd, waardoor de mouse-overfunctie weer correct werkt. Vanaf nu kun je wel de energiemeter uitfilteren, zodat alleen de batterijgegevens worden weergegeven.

**Dynamische Grafieken**
Beide grafieken houden nu rekening met de export correctie wanneer een periode als ontlaad/dure periode is geselecteerd.

**Dynamische En PV Instellingen**
Deze instellingen worden nu verborgen wanneer PV en/of Dynamisch is uitgeschakeld, zodat het dashboard overzichtelijk blijft en alleen relevante opties worden weergegeven.

## Nieuwe functies
**Dynamisch Export Correctie**
Nederlandse gebruikers kunnen nu een export correctie instellen tussen €0,000 en €0,200 per kWh. Vanaf 2027 ontvang je geen belastingteruggave meer voor elektriciteit die je teruglevert aan het net.

**Offgrid Vanaf Het Net**
Wanneer je het offgrid stopcontact gebruikt terwijl de batterij is aangesloten op het elektriciteitsnet wordt het offgrid stopcontact (meestal) gevoed vanuit de batterij. Vanaf nu wordt het offgrid stopcontact in plaats daarvan rechtstreeks vanuit het elektriciteitsnet gevoed wanneer mogelijk.

## Bug fixes
**Dynamisch Handelen + NOM**
Wanneer SOC-bescherming was ingeschakeld, werd deze in deze modus niet gebruikt, waardoor NOM niet kon starten.

**Dynamische Cyclus (Laden/Ontladen)**
De cyclus werd niet altijd correct beëindigd, waardoor onbedoeld extra werd geladen/ontladen. 

**Dynamische Cyclus (Laden)**
De cyclus werd niet altijd correct beëindigd wanneer het maximale laadpercentage ingesteld was onder de 100%.


