### PR TITLE
Next release

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz)
-description: Configuratie Versie (v20260716)
+description: Configuratie Versie (v20260824)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1373,9 +1373,6 @@ actions:
               - condition: trigger
                 id:
                   - aansturing_trigger
-              - condition: trigger
-                id:
-                  - handmatig_trigger
           - condition: state
             entity_id: input_select.zendure_2400_ac_modus_selecteren
             state: Handmatig
@@ -1412,9 +1409,6 @@ actions:
               - condition: trigger
                 id:
                   - aansturing_trigger
-              - condition: trigger
-                id:
-                  - handmatig_trigger
           - condition: state
             entity_id: input_select.zendure_2400_ac_modus_selecteren
             state: Handmatig

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260716"
+        state: "v20260817"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen
@@ -1498,7 +1498,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1527,7 +1527,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1556,7 +1556,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1585,7 +1585,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1614,7 +1614,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1643,7 +1643,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1835,7 +1835,7 @@ rest:
       - name: "Zendure 2400 AC Batterij Serienummers"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% set ns = namespace(sn_list=[]) %}
           {% if not packdata %}
             unknown
@@ -1859,7 +1859,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 1 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1876,7 +1876,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 2 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1893,7 +1893,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 3 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1910,7 +1910,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 4 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1927,7 +1927,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 5 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1944,7 +1944,7 @@ rest:
       - name: "Zendure 2400 AC Batterij 6 Laadpercentage"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_2400_ac_batterij_volgorde') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure 2400 AC Configuratie Versie"
         unique_id: Zendure_2400_AC_Configuratie_Versie
         icon: mdi:one-up
-        state: "v20260817"
+        state: "v20260824"
 
       - name: "Zendure 2400 AC Laatste Kalibratie (Dagen)"
         unique_id: Zendure_2400_AC_Laatste_Kalibratie_Dagen
@@ -1404,24 +1404,21 @@ template:
           {% set laad = states('sensor.zendure_2400_ac_laadpercentage') | float(0) %}
           {% set max_laad = states('sensor.zendure_2400_ac_maximale_laadpercentage') | float(100) %}
           {% set totale_capaciteit = states('sensor.zendure_2400_ac_totale_capaciteit') | float(0) %}
-
           {% set import_eff = states('sensor.zendure_2400_ac_efficientie_import_24u_gemiddelde') | float(0) %}
           {% set rte_totaal = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
-
           {% set effectief_laad = [laad, max_laad] | min %}
           {% set rte_import_equivalent = (rte_totaal / 100) ** 0.5 * 100 %}
-
           {% if import_eff < 70 %}
             {% set effectieve_eff = rte_import_equivalent %}
           {% else %}
             {% set effectieve_eff = import_eff %}
           {% endif %}
-
           {% set effectieve_eff = [effectieve_eff, 100] | min / 100 %}
           {% set benodigd_percentage = max_laad - effectief_laad %}
-
           {% if benodigd_percentage <= 0 %}
             0
+          {% elif effectieve_eff <= 0 %}
+            {{ none }}
           {% else %}
             {{ (benodigd_percentage / 100 * totale_capaciteit / effectieve_eff) | round(2) }}
           {% endif %}
@@ -1432,10 +1429,8 @@ template:
             {% set laad = states('sensor.zendure_2400_ac_laadpercentage') | float(0) %}
             {% set max_laad = states('sensor.zendure_2400_ac_maximale_laadpercentage') | float(100) %}
             {% set totale_capaciteit = states('sensor.zendure_2400_ac_totale_capaciteit') | float(0) %}
-
             {% set effectief_laad = [laad, max_laad] | min %}
             {% set benodigd_percentage = max_laad - effectief_laad %}
-
             {% if benodigd_percentage <= 0 %}
               0
             {% else %}
@@ -1449,17 +1444,22 @@ template:
             {% set import_eff = states('sensor.zendure_2400_ac_efficientie_import_24u_gemiddelde') | float(0) %}
             {% set rte_totaal = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
             {% set rte_import_equivalent = (rte_totaal / 100) ** 0.5 * 100 %}
-            {% if import_eff < 70 %}
+            {% if import_eff >= 70 %}
+              {{ import_eff | round(1) }} %
+            {% elif rte_import_equivalent > 0 %}
               {{ rte_import_equivalent | round(1) }} %
             {% else %}
-              {{ import_eff | round(1) }} %
+              Onbekend
             {% endif %}
           bron_import_efficiëntie: >
             {% set import_eff = states('sensor.zendure_2400_ac_efficientie_import_24u_gemiddelde') | float(0) %}
-            {% if import_eff < 70 %}
+            {% set rte_totaal = states('sensor.zendure_2400_ac_rte_totaal') | float(0) %}
+            {% if import_eff >= 70 %}
+              Import efficiëntie 24u gemiddelde
+            {% elif rte_totaal > 0 %}
               RTE totaal (√RTE × 100)
             {% else %}
-              Import efficiëntie 24u gemiddelde
+              Nog geen geldige efficiëntiedata
             {% endif %}
 
       - name: "Zendure 2400 AC RTE Totaal"

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1,5 +1,5 @@
 alias: Zendure zenSDK (Gielz) Global
-description: Configuration Version (v20260716)
+description: Configuration Version (v20260824)
 triggers:
   - seconds: /5
     id: aansturing_trigger
@@ -1353,9 +1353,6 @@ actions:
               - condition: trigger
                 id:
                   - aansturing_trigger
-              - condition: trigger
-                id:
-                  - handmatig_trigger
           - condition: state
             entity_id: input_select.zendure_operation_mode
             state:
@@ -1390,9 +1387,6 @@ actions:
               - condition: trigger
                 id:
                   - aansturing_trigger
-              - condition: trigger
-                id:
-                  - handmatig_trigger
           - condition: state
             entity_id: input_select.zendure_operation_mode
             state:

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1229,128 +1229,124 @@ views:
                 after: "13:30:00"
                 before: "24:00:00"
             badges: []
-          - type: horizontal-stack
-            cards:
-              - type: custom:apexcharts-card
-                update_interval: 1sec
-                graph_span: 24h
-                apex_config:
-                  noData:
-                    text: Tomorrow's prices will be known from 14:00.
-                  markers:
-                    size: 0
-                    hover:
-                      size: 0
-                  plotOptions:
-                    bar:
-                      columnWidth: 90%
-                  tooltip:
-                    enabledOnSeries:
-                      - 0
-                    followCursor: true
-                    shared: true
-                    intersect: false
-                    enabled: true
-                    x:
-                      format: HH:mm
-                      show: false
-                    "y":
-                      formatter: |
-                        EVAL: (val) => `${val.toFixed(3)} €/kWh`
-                  grid:
-                    show: true
-                    borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
-                    strokeDashArray: 0
-                    padding:
-                      top: -10
-                  chart:
-                    height: 150px
-                    stacked: true
-                    stackOnlyBar: true
-                  yaxis:
-                    - title:
-                        text: ""
-                      decimalsInFloat: 2
-                      forceNiceScale: true
-                      labels:
-                        style:
-                          colors: >-
-                            color-mix(in srgb, var(--primary-text-color) 75%,
-                            transparent)
-                  xaxis:
-                    labels:
-                      show: false
-                    axisTicks:
-                      show: false
-                    axisBorder:
-                      color: >-
-                        color-mix(in srgb, var(--divider-color) 50%,
+          - type: custom:apexcharts-card
+            update_interval: 1sec
+            graph_span: 24h
+            apex_config:
+              noData:
+                text: Tomorrow's prices will be known from 14:00.
+              markers:
+                size: 0
+                hover:
+                  size: 0
+              plotOptions:
+                bar:
+                  columnWidth: 90%
+              tooltip:
+                enabledOnSeries:
+                  - 0
+                followCursor: true
+                shared: true
+                intersect: false
+                enabled: true
+                x:
+                  format: HH:mm
+                  show: false
+                "y":
+                  formatter: |
+                    EVAL: (val) => `${val.toFixed(3)} €/kWh`
+              grid:
+                show: true
+                borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
+                strokeDashArray: 0
+                padding:
+                  top: -10
+              chart:
+                height: 150px
+                stacked: true
+                stackOnlyBar: true
+              yaxis:
+                - title:
+                    text: ""
+                  decimalsInFloat: 2
+                  forceNiceScale: true
+                  labels:
+                    style:
+                      colors: >-
+                        color-mix(in srgb, var(--primary-text-color) 75%,
                         transparent)
-                  legend:
-                    show: false
-                span:
-                  start: day
-                  offset: +1d
-                series:
-                  - entity: sensor.dynamic_lowest_price_period
-                    name: Tomorrow
-                    type: column
-                    float_precision: 3
-                    color: "#e0e0e3"
-                    show:
-                      in_header: false
-                      legend_value: false
-                    data_generator: >
-                      const data = entity.attributes.raw_tomorrow;
+              xaxis:
+                labels:
+                  show: false
+                axisTicks:
+                  show: false
+                axisBorder:
+                  color: color-mix(in srgb, var(--divider-color) 50%, transparent)
+              legend:
+                show: false
+            span:
+              start: day
+              offset: +1d
+            series:
+              - entity: sensor.dynamic_lowest_price_period
+                name: Tomorrow
+                type: column
+                float_precision: 3
+                color: "#e0e0e3"
+                show:
+                  in_header: false
+                  legend_value: false
+                data_generator: >
+                  const data = entity.attributes.raw_tomorrow;
 
-                      if (!data) return [];
+                  if (!data) return [];
 
 
-                      const correction =
-                      parseFloat(hass.states['input_number.dynamic_export_correction'].state
-                      || 0);
+                  const correction =
+                  parseFloat(hass.states['input_number.dynamic_export_correction'].state
+                  || 0);
 
 
-                      return data.map((item, index) => {
-                        const tijdStart = new Date(item.start).getTime();
-                        const duration = item.duration
-                                          ? item.duration * 1000
-                                          : (data[index + 1]
-                                              ? new Date(data[index + 1].start).getTime() - tijdStart
-                                              : 3600000);
-                        const tijdEind = tijdStart + duration;
+                  return data.map((item, index) => {
+                    const tijdStart = new Date(item.start).getTime();
+                    const duration = item.duration
+                                      ? item.duration * 1000
+                                      : (data[index + 1]
+                                          ? new Date(data[index + 1].start).getTime() - tijdStart
+                                          : 3600000);
+                    const tijdEind = tijdStart + duration;
 
-                        let prijs = item.value;
+                    let prijs = item.value;
 
-                        if (item.duur === "Yes") {
-                          prijs = prijs - correction;
-                        }
+                    if (item.duur === "Yes") {
+                      prijs = prijs - correction;
+                    }
 
-                        const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
+                    const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
 
-                        // Standaardkleur: #e0e0e3
-                        let kleur = "rgba(224,224,227,1)";
+                    // Standaardkleur: #e0e0e3
+                    let kleur = "rgba(224,224,227,1)";
 
-                        if (item.goedkoop === "Yes") {
-                          kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
-                        }
-                        else if (item.duur === "Yes") {
-                          kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
-                        }
-                        else {
-                          kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
-                        }
+                    if (item.goedkoop === "Yes") {
+                      kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
+                    }
+                    else if (item.duur === "Yes") {
+                      kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
+                    }
+                    else {
+                      kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
+                    }
 
-                        return {
-                          x: tijdStart,
-                          y: prijs,
-                          fillColor: kleur
-                        };
-                      });
-                visibility:
-                  - condition: time
-                    after: "13:30:00"
-                    before: "24:00:00"
+                    return {
+                      x: tijdStart,
+                      y: prijs,
+                      fillColor: kleur
+                    };
+                  });
+            visibility:
+              - condition: time
+                after: "13:30:00"
+                before: "24:00:00"
           - type: horizontal-stack
             cards:
               - type: tile

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260716"
+        state: "v20260817"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days
@@ -1492,14 +1492,14 @@ rest:
         value_template: >
           {% set states = {1: "Allow", 2: "Forbidden"} %}
           {% set packState = value_json.get('properties', {}).get('gridReverse', 0) | int %}
-          {{ states.get(packState, "Onbekend") }}
+          {{ states.get(packState, "Unknown") }}
 
       - name: "Zendure Battery 1 Cell Balance Status"
         unique_id: zendure_battery_1_cell_balance_status
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1528,7 +1528,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1557,7 +1557,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1586,7 +1586,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1615,7 +1615,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1644,7 +1644,7 @@ rest:
         icon: mdi:battery-heart-variant
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown','unavailable',''] %}
@@ -1836,7 +1836,7 @@ rest:
       - name: "Zendure Battery Serial Numbers"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% set ns = namespace(sn_list=[]) %}
           {% if not packdata %}
             unknown
@@ -1860,7 +1860,7 @@ rest:
       - name: "Zendure Battery 1 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1877,7 +1877,7 @@ rest:
       - name: "Zendure Battery 2 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1894,7 +1894,7 @@ rest:
       - name: "Zendure Battery 3 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1911,7 +1911,7 @@ rest:
       - name: "Zendure Battery 4 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1928,7 +1928,7 @@ rest:
       - name: "Zendure Battery 5 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}
@@ -1945,7 +1945,7 @@ rest:
       - name: "Zendure Battery 6 State Of Charge"
         value_template: >
           {% set volgorde_raw = states('input_text.zendure_setting_battery_order') %}
-          {% set packdata = value_json['packData'] %}
+          {% set packdata = value_json.get('packData', []) %}
           {% if not packdata %}
             unknown
           {% elif volgorde_raw in ['unknown', 'unavailable', ''] %}

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -374,7 +374,7 @@ template:
       - name: "Zendure Configuration Version"
         unique_id: zendure_configuration_version
         icon: mdi:one-up
-        state: "v20260817"
+        state: "v20260824"
 
       - name: "Zendure Last Calibration (Days)"
         unique_id: zendure_last_calibration_days
@@ -1405,24 +1405,21 @@ template:
           {% set laad = states('sensor.zendure_total_state_of_charge') | float(0) %}
           {% set max_laad = states('sensor.zendure_maximum_state_of_charge') | float(100) %}
           {% set totale_capaciteit = states('sensor.zendure_total_capacity') | float(0) %}
-
           {% set import_eff = states('sensor.zendure_import_efficiency_24h') | float(0) %}
           {% set rte_totaal = states('sensor.zendure_rte_total') | float(0) %}
-
           {% set effectief_laad = [laad, max_laad] | min %}
           {% set rte_import_equivalent = (rte_totaal / 100) ** 0.5 * 100 %}
-
           {% if import_eff < 70 %}
             {% set effectieve_eff = rte_import_equivalent %}
           {% else %}
             {% set effectieve_eff = import_eff %}
           {% endif %}
-
           {% set effectieve_eff = [effectieve_eff, 100] | min / 100 %}
           {% set benodigd_percentage = max_laad - effectief_laad %}
-
           {% if benodigd_percentage <= 0 %}
             0
+          {% elif effectieve_eff <= 0 %}
+            {{ none }}
           {% else %}
             {{ (benodigd_percentage / 100 * totale_capaciteit / effectieve_eff) | round(2) }}
           {% endif %}
@@ -1433,10 +1430,8 @@ template:
             {% set laad = states('sensor.zendure_total_state_of_charge') | float(0) %}
             {% set max_laad = states('sensor.zendure_maximum_state_of_charge') | float(100) %}
             {% set totale_capaciteit = states('sensor.zendure_total_capacity') | float(0) %}
-
             {% set effectief_laad = [laad, max_laad] | min %}
             {% set benodigd_percentage = max_laad - effectief_laad %}
-
             {% if benodigd_percentage <= 0 %}
               0
             {% else %}
@@ -1450,17 +1445,23 @@ template:
             {% set import_eff = states('sensor.zendure_import_efficiency_24h') | float(0) %}
             {% set rte_totaal = states('sensor.zendure_rte_total') | float(0) %}
             {% set rte_import_equivalent = (rte_totaal / 100) ** 0.5 * 100 %}
-            {% if import_eff < 70 %}
+            {% if import_eff >= 70 %}
+              {{ import_eff | round(1) }} %
+            {% elif rte_import_equivalent > 0 %}
               {{ rte_import_equivalent | round(1) }} %
             {% else %}
-              {{ import_eff | round(1) }} %
+              Unknown
             {% endif %}
           source_import_efficiency: >
             {% set import_eff = states('sensor.zendure_import_efficiency_24h') | float(0) %}
-            {% if import_eff < 70 %}
+            {% set rte_totaal = states('sensor.zendure_rte_total') | float(0) %}
+
+            {% if import_eff >= 70 %}
+              Import efficiency 24h average
+            {% elif rte_totaal > 0 %}
               RTE total (√RTE × 100)
             {% else %}
-              Import efficiency 24h average
+              No valid efficiency data yet
             {% endif %}
 
       - name: "Zendure RTE Total"


### PR DESCRIPTION
# English (Global)
⚠️ Please make sure to use the correct language update. ⚠️

## Package

**Battery statistics**
Fewer errors when the Zendure connection drops.

**Indication Required Energy**
Fewer errors when Home Assistant is starting.

## Dashboard
**Dynamic**
The Dynamic Tomorrow ApexCharts had an old horizontal line. This has now been removed.

## Automation

**Code Clean Up**
The manual trigger for manual power was still present in the automation but was no longer in use. This has been removed.

<br>
<br>

# Dutch (NL)
⚠️ Zorg ervoor dat je de juiste taalupdate gebruikt. ⚠️

## Packages

**Batterijstatistieken**
Minder foutmeldingen wanneer de Zendure-verbinding wegvalt.

**Indicatie Benodigde Energie**
Minder foutmeldingen wanneer Home Assistant opstart.

## Automatisering

**Code Opschoning**
De handmatige trigger voor handmatig vermogen was nog aanwezig in de automatisering, maar werd niet meer gebruikt. Deze is verwijderd.

