### PR TITLE
Show tooltip time on dynamic price charts when 15-minute interval is on

### DIFF
--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1099,8 +1099,15 @@ views:
                 intersect: false
                 enabled: true
                 x:
-                  format: HH:mm
-                  show: false
+                  show: true
+                  formatter: |
+                    EVAL: (val) => {
+                      const hass = document.querySelector("home-assistant")?.hass;
+                      const kwartier = hass?.states["input_boolean.dynamisch_15_minuten"]?.state === "on";
+                      if (!kwartier) return "";
+                      const d = new Date(val);
+                      return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+                    }
                 "y":
                   formatter: |
                     EVAL: (val) => `${val.toFixed(3)} €/kWh`
@@ -1254,8 +1261,15 @@ views:
                 intersect: false
                 enabled: true
                 x:
-                  format: HH:mm
-                  show: false
+                  show: true
+                  formatter: |
+                    EVAL: (val) => {
+                      const hass = document.querySelector("home-assistant")?.hass;
+                      const kwartier = hass?.states["input_boolean.dynamisch_15_minuten"]?.state === "on";
+                      if (!kwartier) return "";
+                      const d = new Date(val);
+                      return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+                    }
                 "y":
                   formatter: |
                     EVAL: (val) => `${val.toFixed(3)} €/kWh`

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1095,8 +1095,15 @@ views:
                 intersect: false
                 enabled: true
                 x:
-                  format: HH:mm
-                  show: false
+                  show: true
+                  formatter: |
+                    EVAL: (val) => {
+                      const hass = document.querySelector("home-assistant")?.hass;
+                      const kwartier = hass?.states["input_boolean.dynamic_setting_15_minute_interval"]?.state === "on";
+                      if (!kwartier) return "";
+                      const d = new Date(val);
+                      return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+                    }
                 "y":
                   formatter: |
                     EVAL: (val) => `${val.toFixed(3)} €/kWh`
@@ -1252,8 +1259,15 @@ views:
                     intersect: false
                     enabled: true
                     x:
-                      format: HH:mm
-                      show: false
+                      show: true
+                      formatter: |
+                        EVAL: (val) => {
+                          const hass = document.querySelector("home-assistant")?.hass;
+                          const kwartier = hass?.states["input_boolean.dynamic_setting_15_minute_interval"]?.state === "on";
+                          if (!kwartier) return "";
+                          const d = new Date(val);
+                          return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+                        }
                     "y":
                       formatter: |
                         EVAL: (val) => `${val.toFixed(3)} €/kWh`


### PR DESCRIPTION
The "Dynamic Today"/"Dynamic Tomorrow" apexcharts cards hid the x-axis value in the tooltip (tooltip.x.show: false), so with quarter-hourly prices there was no way to tell which block was hovered.

Replace the static format/show pair with a tooltip.x formatter that reads the 15-minute interval input_boolean from hass at render time: it returns HH:mm when the boolean is on, and an empty string otherwise, which ApexCharts hides via its .apexcharts-tooltip-title:empty rule, keeping the previous look for hourly prices.

The NL dashboard uses input_boolean.dynamisch_15_minuten, the global one input_boolean.dynamic_setting_15_minute_interval.

Claude-Session: https://claude.ai/code/session_01PUvM3251og23eXSJuQSFaJ