### PR TITLE
Align Dutch and Global integrations on functional parity

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -340,7 +340,7 @@ actions:
                 before_offset: "-02:00:00"
               - alias: >-
                   sensor.p1_aansturing_vermogen kleiner dan
-                  input_number.zendure_2400_ac_start_opladen_bij
+                  input_number.zendure_2400_ac_opladen_starten_bij
                 condition: template
                 value_template: |
                   {{ states('sensor.p1_aansturing_vermogen') | float(0)
@@ -900,7 +900,7 @@ actions:
               - aansturing_trigger
           - alias: >-
               sensor.p1_aansturing_vermogen groter dan
-              input_number.zendure_2400_ac_start_ontladen_bij
+              input_number.zendure_2400_ac_ontladen_starten_bij
             condition: template
             value_template: |
               {{ states('sensor.p1_aansturing_vermogen') | float(0)
@@ -1144,7 +1144,7 @@ actions:
               - unknown
           - alias: >-
               sensor.p1_aansturing_vermogen kleiner dan
-              input_number.zendure_2400_ac_start_opladen_bij
+              input_number.zendure_2400_ac_opladen_starten_bij
             condition: template
             value_template: |
               {{ states('sensor.p1_aansturing_vermogen') | float(0)

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -6,12 +6,12 @@ input_select:
       - Standby
       - Handmatig
       - Nul op de meter
+      - Alleen slim ontladen
+      - Alleen slim opladen
       - Dynamisch NOM
       - Dynamisch NOM (Duur)
       - Dynamisch Handelen
       - Dynamisch Handelen + NOM
-      - Alleen slim ontladen
-      - Alleen slim opladen
       - Snel opladen
       - Snel ontladen
 

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -346,7 +346,6 @@ actions:
                 value_template: |
                   {{ states('sensor.home_energy_meter_power') | float(0)
                      < states('input_number.zendure_setting_start_charging_at') | float(0) }}
-            enabled: false
           - condition: and
             conditions:
               - condition: state
@@ -377,80 +376,6 @@ actions:
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: Charging to minimum SOC (protection)
-      - conditions:
-          - condition: or
-            conditions:
-              - condition: and
-                conditions:
-                  - condition: trigger
-                    id:
-                      - system_setting_maxsoc
-              - condition: and
-                conditions:
-                  - condition: template
-                    value_template: >-
-                      {{ states('sensor.zendure_maximum_state_of_charge') |
-                      float !=
-                      states('input_number.zendure_setting_maximum_allowed_state_of_charge')
-                      | float }}
-                  - condition: trigger
-                    id:
-                      - aansturing_trigger
-        sequence:
-          - data:
-              sn: "{{ states('sensor.zendure_serial_number') }}"
-              instellingitem: socSet
-              instellinginhoud: >-
-                {{
-                (states('input_number.zendure_setting_maximum_allowed_state_of_charge')
-                | int(0) * 10) }}
-            action: rest_command.zendure_setting
-          - action: logbook.log
-            data:
-              message: >
-                ⚙️Maximum allowed state of charge adjusted to {{
-                states('input_number.zendure_setting_maximum_allowed_state_of_charge')
-                | int }}% —
-              entity_id: input_select.zendure_operation_mode
-              name: " "
-        alias: Adjust maximum allowed state of charge
-      - conditions:
-          - condition: or
-            conditions:
-              - condition: and
-                conditions:
-                  - condition: trigger
-                    id:
-                      - system_setting_minsoc
-              - condition: and
-                conditions:
-                  - condition: template
-                    value_template: >-
-                      {{ states('sensor.zendure_minimum_state_of_charge') |
-                      float !=
-                      states('input_number.zendure_setting_minimum_allowed_state_of_charge')
-                      | float }}
-                  - condition: trigger
-                    id:
-                      - aansturing_trigger
-        sequence:
-          - data:
-              sn: "{{ states('sensor.zendure_serial_number') }}"
-              instellingitem: minSoc
-              instellinginhoud: >-
-                {{
-                (states('input_number.zendure_setting_minimum_allowed_state_of_charge')
-                | int(0) * 10) }}
-            action: rest_command.zendure_setting
-          - action: logbook.log
-            data:
-              message: >
-                ⚙️Minimum allowed state of charge adjusted to {{
-                states('input_number.zendure_setting_minimum_allowed_state_of_charge')
-                | int }}% —
-              entity_id: input_select.zendure_operation_mode
-              name: " "
-        alias: Adjust minimum allowed state of charge
       - conditions:
           - condition: or
             conditions:
@@ -523,6 +448,80 @@ actions:
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: " Adjust maximum discharge power"
+      - conditions:
+          - condition: or
+            conditions:
+              - condition: and
+                conditions:
+                  - condition: trigger
+                    id:
+                      - system_setting_minsoc
+              - condition: and
+                conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ states('sensor.zendure_minimum_state_of_charge') |
+                      float !=
+                      states('input_number.zendure_setting_minimum_allowed_state_of_charge')
+                      | float }}
+                  - condition: trigger
+                    id:
+                      - aansturing_trigger
+        sequence:
+          - data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
+              instellingitem: minSoc
+              instellinginhoud: >-
+                {{
+                (states('input_number.zendure_setting_minimum_allowed_state_of_charge')
+                | int(0) * 10) }}
+            action: rest_command.zendure_setting
+          - action: logbook.log
+            data:
+              message: >
+                ⚙️Minimum allowed state of charge adjusted to {{
+                states('input_number.zendure_setting_minimum_allowed_state_of_charge')
+                | int }}% —
+              entity_id: input_select.zendure_operation_mode
+              name: " "
+        alias: Adjust minimum allowed state of charge
+      - conditions:
+          - condition: or
+            conditions:
+              - condition: and
+                conditions:
+                  - condition: trigger
+                    id:
+                      - system_setting_maxsoc
+              - condition: and
+                conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ states('sensor.zendure_maximum_state_of_charge') |
+                      float !=
+                      states('input_number.zendure_setting_maximum_allowed_state_of_charge')
+                      | float }}
+                  - condition: trigger
+                    id:
+                      - aansturing_trigger
+        sequence:
+          - data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
+              instellingitem: socSet
+              instellinginhoud: >-
+                {{
+                (states('input_number.zendure_setting_maximum_allowed_state_of_charge')
+                | int(0) * 10) }}
+            action: rest_command.zendure_setting
+          - action: logbook.log
+            data:
+              message: >
+                ⚙️Maximum allowed state of charge adjusted to {{
+                states('input_number.zendure_setting_maximum_allowed_state_of_charge')
+                | int }}% —
+              entity_id: input_select.zendure_operation_mode
+              name: " "
+        alias: Adjust maximum allowed state of charge
       - conditions:
           - condition: trigger
             id:
@@ -1127,7 +1126,7 @@ actions:
               - unknown
               - Discharge Limit Reached
           - alias: >-
-              sensor.home_energy_meter_power kleiner dan
+              sensor.home_energy_meter_power lower then
               input_number.zendure_setting_start_charging_at
             condition: template
             value_template: |

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1229,128 +1229,126 @@ views:
                 after: "13:30:00"
                 before: "24:00:00"
             badges: []
-          - type: horizontal-stack
-            cards:
-              - type: custom:apexcharts-card
-                update_interval: 1sec
-                graph_span: 24h
-                apex_config:
-                  noData:
-                    text: Tomorrow's prices will be known from 14:00.
-                  markers:
-                    size: 0
-                    hover:
-                      size: 0
-                  plotOptions:
-                    bar:
-                      columnWidth: 90%
-                  tooltip:
-                    enabledOnSeries:
-                      - 0
-                    followCursor: true
-                    shared: true
-                    intersect: false
-                    enabled: true
-                    x:
-                      format: HH:mm
-                      show: false
-                    "y":
-                      formatter: |
-                        EVAL: (val) => `${val.toFixed(3)} €/kWh`
-                  grid:
-                    show: true
-                    borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
-                    strokeDashArray: 0
-                    padding:
-                      top: -10
-                  chart:
-                    height: 150px
-                    stacked: true
-                    stackOnlyBar: true
-                  yaxis:
-                    - title:
-                        text: ""
-                      decimalsInFloat: 2
-                      forceNiceScale: true
-                      labels:
-                        style:
-                          colors: >-
-                            color-mix(in srgb, var(--primary-text-color) 75%,
-                            transparent)
-                  xaxis:
-                    labels:
-                      show: false
-                    axisTicks:
-                      show: false
-                    axisBorder:
-                      color: >-
-                        color-mix(in srgb, var(--divider-color) 50%,
+          - type: custom:apexcharts-card
+            update_interval: 1sec
+            graph_span: 24h
+            apex_config:
+              noData:
+                text: Tomorrow's prices will be known from 14:00.
+              markers:
+                size: 0
+                hover:
+                  size: 0
+              plotOptions:
+                bar:
+                  columnWidth: 90%
+              tooltip:
+                enabledOnSeries:
+                  - 0
+                followCursor: true
+                shared: true
+                intersect: false
+                enabled: true
+                x:
+                  format: HH:mm
+                  show: false
+                "y":
+                  formatter: |
+                    EVAL: (val) => `${val.toFixed(3)} €/kWh`
+              grid:
+                show: true
+                borderColor: color-mix(in srgb, var(--divider-color) 50%, transparent)
+                strokeDashArray: 0
+                padding:
+                  top: -10
+              chart:
+                height: 150px
+                stacked: true
+                stackOnlyBar: true
+              yaxis:
+                - title:
+                    text: ""
+                  decimalsInFloat: 2
+                  forceNiceScale: true
+                  labels:
+                    style:
+                      colors: >-
+                        color-mix(in srgb, var(--primary-text-color) 75%,
                         transparent)
-                  legend:
-                    show: false
-                span:
-                  start: day
-                  offset: +1d
-                series:
-                  - entity: sensor.dynamic_lowest_price_period
-                    name: Tomorrow
-                    type: column
-                    float_precision: 3
-                    color: "#e0e0e3"
-                    show:
-                      in_header: false
-                      legend_value: false
-                    data_generator: >
-                      const data = entity.attributes.raw_tomorrow;
+              xaxis:
+                labels:
+                  show: false
+                axisTicks:
+                  show: false
+                axisBorder:
+                  color: >-
+                    color-mix(in srgb, var(--divider-color) 50%,
+                    transparent)
+              legend:
+                show: false
+            span:
+              start: day
+              offset: +1d
+            series:
+              - entity: sensor.dynamic_lowest_price_period
+                name: Tomorrow
+                type: column
+                float_precision: 3
+                color: "#e0e0e3"
+                show:
+                  in_header: false
+                  legend_value: false
+                data_generator: >
+                  const data = entity.attributes.raw_tomorrow;
 
-                      if (!data) return [];
+                  if (!data) return [];
 
 
-                      const correction =
-                      parseFloat(hass.states['input_number.dynamic_export_correction'].state
-                      || 0);
+                  const correction =
+                  parseFloat(hass.states['input_number.dynamic_export_correction'].state
+                  || 0);
 
 
-                      return data.map((item, index) => {
-                        const tijdStart = new Date(item.start).getTime();
-                        const duration = item.duration
-                                          ? item.duration * 1000
-                                          : (data[index + 1]
-                                              ? new Date(data[index + 1].start).getTime() - tijdStart
-                                              : 3600000);
-                        const tijdEind = tijdStart + duration;
+                  return data.map((item, index) => {
+                    const tijdStart = new Date(item.start).getTime();
+                    const duration = item.duration
+                                      ? item.duration * 1000
+                                      : (data[index + 1]
+                                          ? new Date(data[index + 1].start).getTime() - tijdStart
+                                          : 3600000);
+                    const tijdEind = tijdStart + duration;
 
-                        let prijs = item.value;
+                    let prijs = item.value;
 
-                        if (item.duur === "Yes") {
-                          prijs = prijs - correction;
-                        }
+                    if (item.duur === "Yes") {
+                      prijs = prijs - correction;
+                    }
 
-                        const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
+                    const verleden = Date.now() >= tijdEind;  // alleen volledig verlopen blokken
 
-                        // Standaardkleur: #e0e0e3
-                        let kleur = "rgba(224,224,227,1)";
+                    // Standaardkleur: #e0e0e3
+                    let kleur = "rgba(224,224,227,1)";
 
-                        if (item.goedkoop === "Yes") {
-                          kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
-                        }
-                        else if (item.duur === "Yes") {
-                          kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
-                        }
-                        else {
-                          kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
-                        }
+                    if (item.goedkoop === "Yes") {
+                      kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
+                    }
+                    else if (item.duur === "Yes") {
+                      kleur = verleden ? "rgba(197,59,44,0.15)" : "rgba(197,59,44,1)";
+                    }
+                    else {
+                      kleur = verleden ? "rgba(162,162,163,0.15)" : "rgba(162,162,163,1)";
+                    }
 
-                        return {
-                          x: tijdStart,
-                          y: prijs,
-                          fillColor: kleur
-                        };
-                      });
-                visibility:
-                  - condition: time
-                    after: "13:30:00"
-                    before: "24:00:00"
+                    return {
+                      x: tijdStart,
+                      y: prijs,
+                      fillColor: kleur
+                    };
+                  });
+            visibility:
+              - condition: time
+                after: "13:30:00"
+                before: "24:00:00"
           - type: horizontal-stack
             cards:
               - type: tile
@@ -2781,6 +2779,16 @@ views:
                   action: more-info
           - type: markdown
             content: >-
+              <ha-alert alert-type="error">Warning</ha-alert>The minimum allowed
+              state of charge is set below 10%. This is not recommended by
+              Zendure.
+            text_only: true
+            visibility:
+              - condition: numeric_state
+                entity: sensor.zendure_minimum_state_of_charge
+                below: 10
+          - type: markdown
+            content: >-
               <ha-alert alert-type="info">Help text</ha-alert>Set the minimum
               and maximum allowed state of charge percentages here.
 
@@ -2794,16 +2802,6 @@ views:
               - condition: state
                 entity: input_boolean.dashboard_setting_show_help
                 state: "on"
-          - type: markdown
-            content: >-
-              <ha-alert alert-type="error">Warning</ha-alert>The minimum allowed
-              state of charge is set below 10%. This is not recommended by
-              Zendure.
-            text_only: true
-            visibility:
-              - condition: numeric_state
-                entity: sensor.zendure_minimum_state_of_charge
-                below: 10
           - type: entities
             entities:
               - entity: input_boolean.zendure_setting_soc_protection_disabled
@@ -2853,7 +2851,7 @@ views:
               You can also set a custom battery order here under **Battery
               Order⚙️**. This allows you to define a different order of the
               batteries yourself. The correct order can be determined using
-              **sensor.zendure_battery_serienumbers** and the sticker on the
+              **sensor.zendure_battery_serial_numbers** and the sticker on the
               battery(ies). This ensures that the battery temperatures and
               charge percentages follow the correct order as they are physically
               stacked.

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -1782,8 +1782,8 @@ rest:
             {% set mapping = {
               5: 2.88,
               70: 1.92,
-              300: 1.92,
               250: 0.96,
+              300: 1.92,
               350: 2.88,
               500: 2.40
             } %}
@@ -2236,7 +2236,7 @@ rest:
          {% else %}
           Not Charging
           {% endif %}
-        icon: mdi:clock-time-four-outline
+        icon: mdi:clock-time-eight-outline
         unique_id: zendure_indication_remaining_charge_time
 
       - name: "Zendure Inverter Temperature"


### PR DESCRIPTION
Reconciles the non-language differences between the Dutch (NL) and Global (EN) integration variants.

The two versions were compared structurally rather than textually — entity IDs are translated too, so a raw diff is useless. A positional NL↔EN identifier map was built across every domain, then the files were normalised and compared on logic, numeric constants, REST payloads and referential integrity. **All numeric thresholds, REST command payloads and URLs, sensor units, device/state classes and template logic already matched exactly.** The changes below cover everything that did not.

## Behaviour

**Global: re-enable the SOC-protection gate** (`automation_global.yaml`)

`enabled: false` sat on the OR condition gating the battery SOC-protection branch:

```yaml
- condition: or
  conditions:
    - condition: sun          # sunrise+2h .. sunset-2h
    - condition: template     # meter power < start_charging_at
  enabled: false              # ← removed
```

A disabled condition is skipped by HA, so the emergency 1200 W recharge below minimum SOC could fire at any hour, including grid-charging at night. The Dutch version has this condition active. This is the only change in the PR that alters what the system does.

**Global: reorder the four device-setting sync branches** in the `System` block to the Dutch order — `chargeMaxLimit` → `inverseMaxPower` → `minSoc` → `socSet`. `choose` runs only the first matching branch, so on each 5s tick this decides which out-of-sync setting is pushed to the device first. Branch contents are byte-identical to before, verified by hashing each branch pre- and post-move.

## UI

- **Dutch: adopt the Global mode ordering** in `input_select`, grouping the `Smart*` options together before the `Dynamic*` ones. Same 11 options; the mode→action mapping is untouched.
- **Global: unwrap the tomorrow-prices chart** from a redundant single-child `horizontal-stack`. Card composition is now identical between the two dashboards — this was the only structural difference in the entire dashboard.
- **Global: move the "below 10% SOC" error alert above its help text**, so the warning is not buried beneath a paragraph. Matches the Dutch ordering.
- **Global: use `mdi:clock-time-eight-outline`** for the remaining-charge-time sensor, matching both its discharge counterpart and the Dutch version.

## Documentation and dead references

- **Global**: `sensor.zendure_battery_serienumbers` in dashboard help text → `sensor.zendure_battery_serial_numbers`. Users copying the old string would get nothing.
- **Dutch**: three condition aliases named `input_number.zendure_2400_ac_start_[ont]laden_bij`, which do not exist. Corrected to `..._[ont]laden_starten_bij`, already used correctly in the adjacent `value_template`s. Display-only text in the automation editor; evaluation was never affected.
- **Global**: translated the one remaining Dutch condition alias covering the same charging condition.
- **Global**: sorted the battery-capacity mapping keys to match Dutch. No runtime effect on a Jinja dict lookup; keeps the two packages diffable.

## Deliberately left alone

- The `state_content` difference on the home energy meter tile (`state` in Global, `[name, state]` in Dutch).
- `handmatig_trigger`, referenced in the Manual Control conditions of **both** automations but defined in neither `triggers:` list. Benign — those conditions also accept `aansturing_trigger`, which fires every 5s — and it is identical in both versions, so it is a shared latent bug rather than a discrepancy. Worth its own issue.
- Untranslated Dutch tokens in the Global version (`n.v.t.`, `Onbekend`, the `duurste_na_eerste_goedkope` attribute, `instellingitem`/`instellinginhoud` REST keys, several trigger IDs, the `Geschiedenis` view title). All verified internally consistent, so none of them break anything — they are translation debt, not defects.

## Verification

- All six YAML files parse.
- Numeric-constant sequences identical across all three file pairs (immune to line reflowing).
- Referential integrity re-checked per version: the Dutch automation's dangling references dropped 7 → 5 and the Global dashboard's 4 → 3, with every remainder being either a service-call name or an intentional example entity in help text.
- Dashboard leaf-card content hashes compared before/after: exactly one card changed (the typo fix); the unwrap and reorder touched containers only.
- Setting-sync branch contents hashed before/after the move: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HL6H4ooz4MBdry6FjDTTg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL6H4ooz4MBdry6FjDTTg5)_

## Summary by Sourcery

Align the Dutch and Global integrations while restoring the Global SOC-protection behavior and correcting inconsistent references and presentation.

Bug Fixes:
- Re-enable the Global battery state-of-charge protection gate so emergency charging is restricted to the intended operating conditions.
- Correct stale entity references and condition aliases in the integration’s user-facing configuration and dashboard help text.

Enhancements:
- Align Global and Dutch automation setting synchronization order, operating-mode ordering, dashboard layout, warning placement, sensor iconography, and capacity mapping presentation.
- Bring the Global and Dutch integration variants into functional and structural parity without changing existing thresholds, payloads, or template behavior.

Documentation:
- Update Global dashboard guidance to reference the correct battery serial-number sensor.