### PR TITLE
Allow custom time range for search of cheap/expensive slots

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -10,6 +10,9 @@ triggers:
   - at: "00:00:00"
     id: dynamisch_middernacht
     trigger: time
+  - at: "23:59:30"
+    id: dynamisch_voor_middernacht
+    trigger: time
   - entity_id:
       - input_select.zendure_2400_ac_modus_selecteren
     id: modus_trigger
@@ -612,6 +615,7 @@ actions:
               entity_id:
                 - input_text.dynamisch_handmatige_periode
                 - input_text.dynamisch_handmatige_periode_morgen
+                - input_text.dynamisch_handmatige_periode_volgende
         alias: Advies instellingen overnemen
       - conditions:
           - condition: trigger
@@ -1447,6 +1451,24 @@ actions:
       - conditions:
           - condition: trigger
             id:
+              - dynamisch_voor_middernacht
+          - condition: template
+            value_template: >-
+              {{
+              states('input_text.dynamisch_nordpool_sensor').lower().startswith('sensor')
+              }}
+            alias: input_text.dynamisch_nordpool_sensor is gevuld
+        sequence:
+          - alias: Bewaar berekende handmatige periode voor morgen
+            target:
+              entity_id: input_text.dynamisch_handmatige_periode_volgende
+            data:
+              value: "{% set berekend = states('sensor.dynamisch_handmatige_periode_volgende_dag') %}{{ '' if berekend in ['unknown', 'unavailable'] else berekend[:255] }}"
+            action: input_text.set_value
+        alias: Berekende handmatige periode voor de volgende dag bewaren
+      - conditions:
+          - condition: trigger
+            id:
               - dynamisch_middernacht
           - condition: template
             value_template: >-
@@ -1475,11 +1497,17 @@ actions:
             target:
               entity_id: input_text.dynamisch_handmatige_periode
             data:
-              value: "{{ states('input_text.dynamisch_handmatige_periode_morgen') }}"
+              value: "{% set berekend = states('input_text.dynamisch_handmatige_periode_volgende') %}{% set morgen = states('input_text.dynamisch_handmatige_periode_morgen') %}{{ berekend if berekend not in ['unknown', 'unavailable', ''] else ('' if morgen in ['unknown', 'unavailable'] else morgen) }}"
             action: input_text.set_value
           - alias: Reset handmatige periode van morgen
             target:
               entity_id: input_text.dynamisch_handmatige_periode_morgen
+            data:
+              value: ""
+            action: input_text.set_value
+          - alias: Reset berekende handmatige periode
+            target:
+              entity_id: input_text.dynamisch_handmatige_periode_volgende
             data:
               value: ""
             action: input_text.set_value

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1322,7 +1322,7 @@ views:
 
                     let prijs = item.value;
 
-                    if (item.duur === "ja") {
+                    if (item.duur === "ja" || item.overdracht === "D") {
                       prijs = prijs - correctie;
                     }
 
@@ -1332,7 +1332,13 @@ views:
                     let kleur = "rgba(224,224,227,1)";
 
 
-                    if (item.goedkoop === "ja") {
+                    if (item.overdracht === "G") {
+                      kleur = verleden ? "rgba(79,195,168,0.15)" : "rgba(79,195,168,1)";
+                    }
+                    else if (item.overdracht === "D") {
+                      kleur = verleden ? "rgba(224,128,116,0.15)" : "rgba(224,128,116,1)";
+                    }
+                    else if (item.goedkoop === "ja") {
                       kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
                     }
                     else if (item.duur === "ja") {

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1394,8 +1394,13 @@ views:
                 name: Duurste Periodes Morgen
               - entity: input_text.dynamisch_handmatige_periode_morgen
                 name: Handmatige Periodes Morgen
-              - entity: sensor.dynamisch_handmatige_periode_volgende_dag
-                name: Handmatige Periodes Voor Morgen (berekend)
+              - type: conditional
+                conditions:
+                  - entity: sensor.dynamisch_handmatige_periode_volgende_dag
+                    state_not: ""
+                row:
+                  entity: sensor.dynamisch_handmatige_periode_volgende_dag
+                  name: Handmatige Periodes Voor Morgen (berekend)
             visibility:
               - condition: time
                 after: "13:30:00"

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1388,6 +1388,8 @@ views:
                 name: Duurste Periodes Morgen
               - entity: input_text.dynamisch_handmatige_periode_morgen
                 name: Handmatige Periodes Morgen
+              - entity: sensor.dynamisch_handmatige_periode_volgende_dag
+                name: Handmatige Periodes Voor Morgen (berekend)
             visibility:
               - condition: time
                 after: "13:30:00"

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -994,11 +994,8 @@ template:
         icon: mdi:percent-box
         unit_of_measurement: "%"
         state: >
-          {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
-          {% set duurste = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
-
-          {% set goedkope_uren = uren | selectattr('goedkoop','equalto','ja') | list %}
-          {% set dure_uren = duurste | list %}
+          {% set goedkope_uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'goedkope_in_venster') or [] %}
+          {% set dure_uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
 
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
@@ -1032,26 +1029,28 @@ template:
               {{ ns.result | join(';') }}
             {% endif %}
           goedkoopste_periode: >
-            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
-            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | sort(attribute='start') | list %}
+            {% set vandaag = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] %}
+            {% set basisdag = (vandaag | first).start[:10] if vandaag | count > 0 else '' %}
+            {% set goedkoop = (state_attr('sensor.dynamisch_goedkoopste_periode', 'goedkope_in_venster') or []) | sort(attribute='start') | list %}
             [
             {% for uur in goedkoop %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }}{{ ' (+1)' if basisdag != '' and uur.start[:10] != basisdag else '' }} - €{{ '%.4f' | format(uur.value) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
           duurste_periode: >
-            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
-            {% set duur = uren | sort(attribute='value', reverse=true) | list %}
+            {% set vandaag = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] %}
+            {% set basisdag = (vandaag | first).start[:10] if vandaag | count > 0 else '' %}
+            {% set duur = state_attr('sensor.dynamisch_goedkoopste_periode', 'duurste_na_eerste_goedkope') or [] %}
+            {% set duur = duur | sort(attribute='value', reverse=true) | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }}{{ ' (+1)' if basisdag != '' and uur.start[:10] != basisdag else '' }} - €{{ '%.4f' | format(uur.value) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
           gemiddelde_goedkoop: >
-            {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
-            {% set goedkoop = uren | selectattr('goedkoop','equalto','ja') | list %}
+            {% set goedkoop = state_attr('sensor.dynamisch_goedkoopste_periode', 'goedkope_in_venster') or [] %}
             {% if goedkoop | count > 0 %}
               €{{ '%.4f' % (goedkoop | map(attribute='value') | sum / goedkoop | count) }}
             {% else %}
@@ -1321,12 +1320,26 @@ template:
                   'duur': ('ja' if uur.start in d else 'nee')}] -%}
             {%- endfor -%}
             {{- ns.l | to_json -}}
-          duurste_na_eerste_goedkope: >-
-            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+          goedkope_in_venster: >-
+            {%- set vandaag = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
             {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
-            {%- set g = sel.get('tg', []) -%}
-            {%- set d = sel.get('td', []) -%}
-            {%- set goedkope = prijzen
+            {%- set g = sel.get('tg', []) + sel.get('cg', []) -%}
+            {%- set d = sel.get('td', []) + sel.get('cd', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in vandaag + morgen if uur.start in g -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': 'ja', 'duur': ('ja' if uur.start in d else 'nee')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope: >-
+            {%- set vandaag = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) + sel.get('cg', []) -%}
+            {%- set d = sel.get('td', []) + sel.get('cd', []) -%}
+            {%- set venster = vandaag + morgen -%}
+            {%- set goedkope = venster
               | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
@@ -1335,8 +1348,8 @@ template:
               | list -%}
             {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
             {%- set ns = namespace(l=[]) -%}
-            {%- if prijzen and eerste_goedkoop -%}
-              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+            {%- if eerste_goedkoop -%}
+              {%- for uur in venster if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
                 {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
                     'goedkoop': ('ja' if uur.start in g else 'nee'), 'duur': 'ja'}] -%}
               {%- endfor -%}

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -1313,11 +1313,14 @@ template:
             {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
             {%- set g = sel.get('mg', []) -%}
             {%- set d = sel.get('md', []) -%}
+            {%- set cg = sel.get('cg', []) -%}
+            {%- set cd = sel.get('cd', []) -%}
             {%- set ns = namespace(l=[]) -%}
             {%- for uur in prijzen -%}
               {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
                   'goedkoop': ('ja' if uur.start in g else 'nee'),
-                  'duur': ('ja' if uur.start in d else 'nee')}] -%}
+                  'duur': ('ja' if uur.start in d else 'nee'),
+                  'overdracht': ('G' if uur.start in cg else ('D' if uur.start in cd else ''))}] -%}
             {%- endfor -%}
             {{- ns.l | to_json -}}
           goedkope_in_venster: >-

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -91,13 +91,19 @@ input_text:
   dynamisch_handmatige_periode:
     name: Dynamisch Handmatige Periode
     icon: mdi:view-grid
-    max: 250
+    max: 255
     mode: text
 
   dynamisch_handmatige_periode_morgen:
     name: Dynamisch Handmatige Periode Morgen
     icon: mdi:view-grid
-    max: 250
+    max: 255
+    mode: text
+
+  dynamisch_handmatige_periode_volgende:
+    name: Dynamisch Handmatige Periode Volgende Dag
+    icon: mdi:view-grid-outline
+    max: 255
     mode: text
 
 input_number:
@@ -621,6 +627,279 @@ template:
               0
             {% endif %}
 
+      - name: "Dynamisch Periode Planning"
+        unique_id: dynamisch_periode_planning
+        icon: mdi:calendar-clock
+        state: >-
+          {{ 'Ja' if state_attr('sensor.dynamisch_nordpool', 'raw_today') else 'Nee' }}
+        attributes:
+          selection: >-
+            {%- macro zen_parse(txt) -%}
+              {%- set ns = namespace(items=[]) -%}
+              {%- for deel in txt.split(';') -%}
+                {%- set t = deel | trim | replace(' ', '') | upper -%}
+                {%- if t | length > 0 -%}
+                  {%- if t | regex_match('^\+?Z[GD]?[0-9]{1,2}:[0-9]{2}-[0-9]{1,2}:[0-9]{2}V?$') -%}
+                    {%- set plus = t[0] == '+' -%}
+                    {%- set b1 = t[1:] if plus else t -%}
+                    {%- set vast = b1[-1] == 'V' -%}
+                    {%- set b2 = b1[:-1] if vast else b1 -%}
+                    {%- set kind = b2[1] if b2[1] in ['G', 'D'] else 'B' -%}
+                    {%- set rng = (b2[1:] if kind == 'B' else b2[2:]).split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = '%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1]) -%}
+                    {%- set ns.items = ns.items + [{'k': 'z', 'kind': kind, 'a': a, 'b': b, 'nd': (plus or b <= a), 'vast': vast, 'tok': t}] -%}
+                  {%- elif t | regex_match('^[+-][GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                    {%- set rng = t[2:].split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                    {%- set ns.items = ns.items + [{'k': 'm', 'sign': t[0], 'type': t[1], 'a': a, 'b': b, 'tok': t}] -%}
+                  {%- elif t | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                    {%- set rng = t[1:].split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                    {%- set ns.items = ns.items + [{'k': 'a', 'type': t[0], 'a': a, 'b': b, 'tok': t}] -%}
+                  {%- else -%}
+                    {%- set ns.items = ns.items + [{'k': 'x', 'tok': t}] -%}
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{- ns.items | to_json -}}
+            {%- endmacro -%}
+            {%- macro zen_plan(eigen, extra, P, n_g, n_d, slot_delta) -%}
+              {%- if eigen | count == 0 -%}
+                {{- {'g': [], 'd': []} | to_json -}}
+              {%- else -%}
+                {%- set basis = eigen[0].start | as_datetime -%}
+                {%- set tz = basis.tzinfo -%}
+                {%- set dag = basis.strftime('%Y-%m-%d') -%}
+                {%- set alle = eigen + extra -%}
+                {%- set ns = namespace(g=[], d=[]) -%}
+                {%- set vaste = P | selectattr('k', 'eq', 'a') | list -%}
+                {%- if vaste | count > 0 -%}
+                  {%- for it in vaste -%}
+                    {%- set s_dt = strptime(dag ~ ' ' ~ it.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                    {%- if it.b -%}
+                      {%- set e0 = strptime(dag ~ ' ' ~ it.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                      {%- set e_dt = (e0 + timedelta(days=1) if e0 <= s_dt else e0) + timedelta(seconds=1) -%}
+                    {%- else -%}
+                      {%- set e_dt = s_dt + slot_delta -%}
+                    {%- endif -%}
+                    {%- for u in eigen -%}
+                      {%- if (u.start | as_datetime) < e_dt and (u.end | as_datetime) > s_dt -%}
+                        {%- if it.type == 'G' -%}
+                          {%- set ns.g = ns.g + [u.start] -%}
+                        {%- else -%}
+                          {%- set ns.d = ns.d + [u.start] -%}
+                        {%- endif -%}
+                      {%- endif -%}
+                    {%- endfor -%}
+                  {%- endfor -%}
+                  {%- set ns.g = ns.g | unique | list -%}
+                  {%- set ns.d = ns.d | unique | list -%}
+                {%- else -%}
+                  {%- set zoek = P | selectattr('k', 'eq', 'z') | list -%}
+                  {%- for soort in ['G', 'D'] -%}
+                    {%- set vensters = zoek | selectattr('kind', 'in', ['B', soort]) | list -%}
+                    {%- set pool = namespace(l=[]) -%}
+                    {%- if vensters | count > 0 -%}
+                      {%- for u in alle -%}
+                        {%- set us = u.start | as_datetime -%}
+                        {%- set raak = namespace(v=false) -%}
+                        {%- for w in vensters -%}
+                          {%- set ws = strptime(dag ~ ' ' ~ w.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                          {%- set w0 = strptime(dag ~ ' ' ~ w.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                          {%- set we = w0 + timedelta(days=1) if w.nd else w0 -%}
+                          {%- if us >= ws and us < we -%}
+                            {%- set raak.v = true -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {%- if raak.v -%}
+                          {%- set pool.l = pool.l + [u] -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+                    {%- else -%}
+                      {%- set pool.l = eigen | list -%}
+                    {%- endif -%}
+                    {%- set gesorteerd = pool.l | sort(attribute='value') | list -%}
+                    {%- if soort == 'G' -%}
+                      {%- set ns.g = (gesorteerd[:n_g] | map(attribute='start') | list) if n_g > 0 else [] -%}
+                    {%- else -%}
+                      {%- set ns.d = (gesorteerd[-n_d:] | map(attribute='start') | list) if n_d > 0 else [] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                {%- endif -%}
+                {%- for it in P if it.k == 'm' -%}
+                  {%- set s_dt = strptime(dag ~ ' ' ~ it.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                  {%- if it.b -%}
+                    {%- set e0 = strptime(dag ~ ' ' ~ it.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                    {%- set e_dt = (e0 + timedelta(days=1) if e0 <= s_dt else e0) + timedelta(seconds=1) -%}
+                  {%- else -%}
+                    {%- set e_dt = s_dt + slot_delta -%}
+                  {%- endif -%}
+                  {%- set tr = namespace(l=[]) -%}
+                  {%- for u in eigen -%}
+                    {%- if (u.start | as_datetime) < e_dt and (u.end | as_datetime) > s_dt -%}
+                      {%- set tr.l = tr.l + [u.start] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                  {%- if it.sign == '+' -%}
+                    {%- if it.type == 'G' -%}
+                      {%- set ns.g = (ns.g + tr.l) | unique | list -%}
+                      {%- set ns.d = ns.d | reject('in', tr.l) | list -%}
+                    {%- else -%}
+                      {%- set ns.d = (ns.d + tr.l) | unique | list -%}
+                      {%- set ns.g = ns.g | reject('in', tr.l) | list -%}
+                    {%- endif -%}
+                  {%- else -%}
+                    {%- if it.type == 'G' -%}
+                      {%- set ns.g = ns.g | reject('in', tr.l) | list -%}
+                    {%- else -%}
+                      {%- set ns.d = ns.d | reject('in', tr.l) | list -%}
+                    {%- endif -%}
+                  {%- endif -%}
+                {%- endfor -%}
+                {{- {'g': ns.g, 'd': ns.d} | to_json -}}
+              {%- endif -%}
+            {%- endmacro -%}
+            {%- set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') -%}
+            {%- set slot_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) -%}
+            {%- set vandaag = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set tv = states('input_text.dynamisch_handmatige_periode') -%}
+            {%- set tm = states('input_text.dynamisch_handmatige_periode_morgen') -%}
+            {%- set tv = '' if tv in ['unknown', 'unavailable'] else tv -%}
+            {%- set tm = '' if tm in ['unknown', 'unavailable'] else tm -%}
+            {%- set plan_v = zen_plan(vandaag, morgen, zen_parse(tv) | from_json,
+                states('input_number.dynamisch_goedkoopste_x_periode') | int(0), states('input_number.dynamisch_duurste_x_periode') | int(0), slot_delta) | from_json -%}
+            {%- set plan_m = zen_plan(morgen, [], zen_parse(tm) | from_json,
+                states('input_number.dynamisch_goedkoopste_x_periode_morgen') | int(0), states('input_number.dynamisch_duurste_x_periode_morgen') | int(0), slot_delta) | from_json -%}
+            {%- set vs = vandaag | map(attribute='start') | list -%}
+            {{- {'tg': plan_v.g | select('in', vs) | list,
+                 'td': plan_v.d | select('in', vs) | list,
+                 'cg': plan_v.g | reject('in', vs) | list,
+                 'cd': plan_v.d | reject('in', vs) | list,
+                 'mg': plan_m.g,
+                 'md': plan_m.d} | to_json -}}
+
+      - name: "Dynamisch Handmatige Periode Volgende Dag"
+        unique_id: dynamisch_handmatige_periode_volgende_dag
+        icon: mdi:calendar-arrow-right
+        state: >-
+          {%- macro zen_parse(txt) -%}
+            {%- set ns = namespace(items=[]) -%}
+            {%- for deel in txt.split(';') -%}
+              {%- set t = deel | trim | replace(' ', '') | upper -%}
+              {%- if t | length > 0 -%}
+                {%- if t | regex_match('^\+?Z[GD]?[0-9]{1,2}:[0-9]{2}-[0-9]{1,2}:[0-9]{2}V?$') -%}
+                  {%- set plus = t[0] == '+' -%}
+                  {%- set b1 = t[1:] if plus else t -%}
+                  {%- set vast = b1[-1] == 'V' -%}
+                  {%- set b2 = b1[:-1] if vast else b1 -%}
+                  {%- set kind = b2[1] if b2[1] in ['G', 'D'] else 'B' -%}
+                  {%- set rng = (b2[1:] if kind == 'B' else b2[2:]).split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = '%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1]) -%}
+                  {%- set ns.items = ns.items + [{'k': 'z', 'kind': kind, 'a': a, 'b': b, 'nd': (plus or b <= a), 'vast': vast, 'tok': t}] -%}
+                {%- elif t | regex_match('^[+-][GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                  {%- set rng = t[2:].split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                  {%- set ns.items = ns.items + [{'k': 'm', 'sign': t[0], 'type': t[1], 'a': a, 'b': b, 'tok': t}] -%}
+                {%- elif t | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                  {%- set rng = t[1:].split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                  {%- set ns.items = ns.items + [{'k': 'a', 'type': t[0], 'a': a, 'b': b, 'tok': t}] -%}
+                {%- else -%}
+                  {%- set ns.items = ns.items + [{'k': 'x', 'tok': t}] -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {{- ns.items | to_json -}}
+          {%- endmacro -%}
+          {%- macro zen_overdracht(morgen, cg, cd, ns) -%}
+            {%- set g = namespace(type='', first='', last='', end='') -%}
+            {%- for u in morgen | sort(attribute='start') -%}
+              {%- set soort = 'G' if u.start in cg else ('D' if u.start in cd else '') -%}
+              {%- if soort != '' and g.type == soort and g.end == u.start -%}
+                {%- set g.last = u.start -%}
+                {%- set g.end = u.end -%}
+              {%- else -%}
+                {%- if g.type != '' -%}
+                  {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+                {%- endif -%}
+                {%- set g.type = soort -%}
+                {%- set g.first = u.start -%}
+                {%- set g.last = u.start -%}
+                {%- set g.end = u.end -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {%- if g.type != '' -%}
+              {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+            {%- endif -%}
+          {%- endmacro -%}
+          {%- set morgen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+          {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+          {%- set tv = states('input_text.dynamisch_handmatige_periode') -%}
+          {%- set tm = states('input_text.dynamisch_handmatige_periode_morgen') -%}
+          {%- set tv = '' if tv in ['unknown', 'unavailable'] else tv -%}
+          {%- set tm = '' if tm in ['unknown', 'unavailable'] else tm -%}
+          {%- set pv = zen_parse(tv) | from_json -%}
+          {%- set pm = zen_parse(tm) | from_json -%}
+          {%- set vast = pv | selectattr('k', 'eq', 'z') | selectattr('vast') | list -%}
+          {%- set vaste_soorten = vast | map(attribute='kind') | list -%}
+          {%- set ns = namespace(tok=[]) -%}
+          {%- for it in vast -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- for it in pm if it.k == 'z' and it.kind not in vaste_soorten -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- for it in pm if it.k in ['a', 'x'] -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {{- zen_overdracht(morgen, sel.get('cg', []), sel.get('cd', []), ns) -}}
+          {%- for it in pm if it.k == 'm' -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- set res = namespace(s='') -%}
+          {%- for t in ns.tok -%}
+            {%- set kandidaat = res.s ~ (';' if res.s | length > 0 else '') ~ t -%}
+            {%- if kandidaat | length <= 255 -%}
+              {%- set res.s = kandidaat -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{- res.s -}}
+        attributes:
+          carry_periods: >-
+            {%- macro zen_overdracht(morgen, cg, cd, ns) -%}
+              {%- set g = namespace(type='', first='', last='', end='') -%}
+              {%- for u in morgen | sort(attribute='start') -%}
+                {%- set soort = 'G' if u.start in cg else ('D' if u.start in cd else '') -%}
+                {%- if soort != '' and g.type == soort and g.end == u.start -%}
+                  {%- set g.last = u.start -%}
+                  {%- set g.end = u.end -%}
+                {%- else -%}
+                  {%- if g.type != '' -%}
+                    {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+                  {%- endif -%}
+                  {%- set g.type = soort -%}
+                  {%- set g.first = u.start -%}
+                  {%- set g.last = u.start -%}
+                  {%- set g.end = u.end -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {%- if g.type != '' -%}
+                {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+              {%- endif -%}
+            {%- endmacro -%}
+            {%- set morgen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set ns = namespace(tok=[]) -%}
+            {{- zen_overdracht(morgen, sel.get('cg', []), sel.get('cd', []), ns) -}}
+            {{- ns.tok | join(';') -}}
+
       - name: "Dynamisch Spread Indicatie"
         unique_id: dynamisch_spread_indicatie
         icon: mdi:percent-box
@@ -639,7 +918,15 @@ template:
           {% endif %}
         attributes:
           handmatige_periode: >
-            {% if states('input_text.dynamisch_handmatige_periode') | length > 0 %}
+            {% set txt = states('input_text.dynamisch_handmatige_periode') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
@@ -722,7 +1009,15 @@ template:
           {% endif %}
         attributes:
           handmatige_periode: >
-            {% if states('input_text.dynamisch_handmatige_periode') | length > 0 %}
+            {% set txt = states('input_text.dynamisch_handmatige_periode') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
@@ -797,7 +1092,15 @@ template:
           {% endif %}
         attributes:
           handmatige_periode: >
-            {% if states('input_text.dynamisch_handmatige_periode_morgen') | length > 0 %}
+            {% set txt = states('input_text.dynamisch_handmatige_periode_morgen') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
@@ -878,7 +1181,15 @@ template:
           {% endif %}
         attributes:
           handmatige_periode: >
-            {% if states('input_text.dynamisch_handmatige_periode_morgen') | length > 0 %}
+            {% set txt = states('input_text.dynamisch_handmatige_periode_morgen') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_tomorrow') or [] %}
@@ -938,362 +1249,120 @@ template:
       - name: "Dynamisch Duurste Periode"
         unique_id: dynamisch_duurste_periode
         icon: mdi:progress-clock
-        state: >
-          {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
-          {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-          {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
-          {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
-          {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-          {% if prijzen is iterable %}
-            {% set ns = namespace(dure_starttijden=[]) %}
-            {% if handmatige | length > 0 %}
-              {% for item in handmatige.split(';') %}
-                {% if item[0] == 'D' %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-              {% endfor %}
-            {% else %}
-              {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-              {% if aantal_duur > 0 %}
-                {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-              {% else %}
-                {% set ns.dure_starttijden = [] %}
-              {% endif %}
-            {% endif %}
-            {% set nu = now().astimezone() %}
-            {% set actief = prijzen
-              | selectattr('start', 'in', ns.dure_starttijden)
+        state: >-
+          {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') -%}
+          {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+          {%- if prijzen is iterable -%}
+            {%- set gekozen = sel.get('td', []) -%}
+            {%- set nu = now().astimezone() -%}
+            {%- set actief = prijzen
+              | selectattr('start', 'in', gekozen)
               | selectattr('start', 'le', nu.isoformat())
               | selectattr('end', 'gt', nu.isoformat())
-              | list %}
-            {{ 'Ja' if actief | length > 0 else 'Nee' }}
-          {% else %}
-            Onbekend
-          {% endif %}
+              | list -%}
+            {{- 'Ja' if actief | length > 0 else 'Nee' -}}
+          {%- else -%}
+            {{- 'Onbekend' -}}
+          {%- endif -%}
         attributes:
-          raw_today: >
-            {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') %}
-            {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goede_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% for uur in prijzen %}
-                    {% if uur.start[11:16] == tijden %}
-                      {% if type == 'G' %}
-                        {% set ns.goede_starttijden = ns.goede_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goede_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'ja' if uur.start in ns.goede_starttijden else 'nee' }}",
-                  "duur": "{{ 'ja' if uur.start in ns.dure_starttijden else 'nee' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
+          raw_today: >-
+            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('ja' if uur.start in g else 'nee'),
+                  'duur': ('ja' if uur.start in d else 'nee')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
 
       - name: "Dynamisch Goedkoopste Periode"
         unique_id: dynamisch_goedkoopste_periode
         icon: mdi:progress-clock
-        state: >
-          {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
-          {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-          {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
-          {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
-          {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-          {% if prijzen is iterable %}
-            {% set ns = namespace(goedkope_starttijden=[]) %}
-            {% if handmatige | length > 0 %}
-              {% for item in handmatige.split(';') %}
-                {% if item[0] == 'G' %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-              {% endfor %}
-            {% else %}
-              {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-              {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-            {% endif %}
-            {% set nu = now().astimezone() %}
-            {% set in_goedkoop_blok = prijzen
-              | selectattr('start', 'in', ns.goedkope_starttijden)
+        state: >-
+          {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') -%}
+          {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+          {%- if prijzen is iterable -%}
+            {%- set gekozen = sel.get('tg', []) -%}
+            {%- set nu = now().astimezone() -%}
+            {%- set actief = prijzen
+              | selectattr('start', 'in', gekozen)
               | selectattr('start', 'le', nu.isoformat())
               | selectattr('end', 'gt', nu.isoformat())
-              | list %}
-            {{ 'Ja' if in_goedkoop_blok | length > 0 else 'Nee' }}
-          {% else %}
-            Onbekend
-          {% endif %}
+              | list -%}
+            {{- 'Ja' if actief | length > 0 else 'Nee' -}}
+          {%- else -%}
+            {{- 'Onbekend' -}}
+          {%- endif -%}
         attributes:
-          raw_today: >
-            {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
-            {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
-            {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
-            {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goedkope_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% if type == 'G' %}
-                        {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'ja' if uur.start in ns.goedkope_starttijden else 'nee' }}",
-                  "duur": "{{ 'ja' if uur.start in ns.dure_starttijden else 'nee' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-          raw_tomorrow: >
-            {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') %}
-            {% set handmatige = states('input_text.dynamisch_handmatige_periode_morgen') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode_morgen') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode_morgen') | int %}
-            {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
-            {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goedkope_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% if type == 'G' %}
-                        {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'ja' if uur.start in ns.goedkope_starttijden else 'nee' }}",
-                  "duur": "{{ 'ja' if uur.start in ns.dure_starttijden else 'nee' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-          duurste_na_eerste_goedkope: >
-            {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode','raw_today') or [] %}
-            {% set goedkope = prijzen
-              | selectattr('goedkoop','eq','ja')
+          raw_today: >-
+            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('ja' if uur.start in g else 'nee'),
+                  'duur': ('ja' if uur.start in d else 'nee')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          raw_tomorrow: >-
+            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('mg', []) -%}
+            {%- set d = sel.get('md', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('ja' if uur.start in g else 'nee'),
+                  'duur': ('ja' if uur.start in d else 'nee')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope: >-
+            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set goedkope = prijzen
+              | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
               | select('!=', None)
               | sort
-              | list %}
-            {% set eerste_goedkoop = goedkope | first if goedkope else none %}
-            {% if prijzen and eerste_goedkoop %}
-              [
-              {% for uur in prijzen
-                if uur.duur == 'ja'
-                and (uur.start | as_datetime > eerste_goedkoop)
-              %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ uur.goedkoop }}",
-                  "duur": "ja"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-          duurste_na_eerste_goedkope_morgen: >
-            {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode','raw_tomorrow') or [] %}
-            {% set goedkope = prijzen
-              | selectattr('goedkoop','eq','ja')
+              | list -%}
+            {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- if prijzen and eerste_goedkoop -%}
+              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+                {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                    'goedkoop': ('ja' if uur.start in g else 'nee'), 'duur': 'ja'}] -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope_morgen: >-
+            {%- set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamisch_periode_planning', 'selection') or {} -%}
+            {%- set g = sel.get('mg', []) -%}
+            {%- set d = sel.get('md', []) -%}
+            {%- set goedkope = prijzen
+              | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
               | select('!=', None)
               | sort
-              | list %}
-            {% set eerste_goedkoop = goedkope | first if goedkope else none %}
-            {% if prijzen and eerste_goedkoop %}
-              [
-              {% for uur in prijzen
-                if uur.duur == 'ja'
-                and (uur.start | as_datetime > eerste_goedkoop)
-              %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ uur.goedkoop }}",
-                  "duur": "ja"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
+              | list -%}
+            {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- if prijzen and eerste_goedkoop -%}
+              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+                {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                    'goedkoop': ('ja' if uur.start in g else 'nee'), 'duur': 'ja'}] -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {{- ns.l | to_json -}}
 
       - name: "Zendure 2400 AC Efficiëntie Export"
         unique_id: zendure_2400_ac_efficientie_export

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -10,6 +10,9 @@ triggers:
   - at: "00:00:00"
     id: dynamisch_middernacht
     trigger: time
+  - at: "23:59:30"
+    id: dynamisch_voor_middernacht
+    trigger: time
   - entity_id:
       - input_select.zendure_operation_mode
     id: modus_trigger
@@ -602,6 +605,7 @@ actions:
               entity_id:
                 - input_text.dynamic_manual_period
                 - input_text.dynamic_manual_period_tomorrow
+                - input_text.dynamic_manual_period_next
             data:
               value: ""
         alias: Set default preferred settings
@@ -1423,6 +1427,24 @@ actions:
       - conditions:
           - condition: trigger
             id:
+              - dynamisch_voor_middernacht
+          - condition: template
+            value_template: >-
+              {{
+              states('input_text.dynamic_setting_nordpool_sensor').lower().startswith('sensor')
+              }}
+            alias: input_text.dynamic_setting_nordpool_sensor is gevuld
+        sequence:
+          - alias: Store calculated manual period for tomorrow
+            target:
+              entity_id: input_text.dynamic_manual_period_next
+            data:
+              value: "{% set berekend = states('sensor.dynamic_next_day_manual_period') %}{{ '' if berekend in ['unknown', 'unavailable'] else berekend[:255] }}"
+            action: input_text.set_value
+        alias: Store the calculated dynamic manual period for the next day
+      - conditions:
+          - condition: trigger
+            id:
               - dynamisch_middernacht
           - condition: template
             value_template: >-
@@ -1452,11 +1474,17 @@ actions:
             target:
               entity_id: input_text.dynamic_manual_period
             data:
-              value: "{{ states('input_text.dynamic_manual_period_tomorrow') }}"
+              value: "{% set berekend = states('input_text.dynamic_manual_period_next') %}{% set morgen = states('input_text.dynamic_manual_period_tomorrow') %}{{ berekend if berekend not in ['unknown', 'unavailable', ''] else ('' if morgen in ['unknown', 'unavailable'] else morgen) }}"
             action: input_text.set_value
           - alias: Reset handmatige periode van morgen
             target:
               entity_id: input_text.dynamic_manual_period_tomorrow
+            data:
+              value: ""
+            action: input_text.set_value
+          - alias: Reset calculated manual period
+            target:
+              entity_id: input_text.dynamic_manual_period_next
             data:
               value: ""
             action: input_text.set_value

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1322,7 +1322,7 @@ views:
 
                         let prijs = item.value;
 
-                        if (item.duur === "Yes") {
+                        if (item.duur === "Yes" || item.overdracht === "D") {
                           prijs = prijs - correction;
                         }
 
@@ -1331,7 +1331,13 @@ views:
                         // Standaardkleur: #e0e0e3
                         let kleur = "rgba(224,224,227,1)";
 
-                        if (item.goedkoop === "Yes") {
+                        if (item.overdracht === "G") {
+                          kleur = verleden ? "rgba(79,195,168,0.15)" : "rgba(79,195,168,1)";
+                        }
+                        else if (item.overdracht === "D") {
+                          kleur = verleden ? "rgba(224,128,116,0.15)" : "rgba(224,128,116,1)";
+                        }
+                        else if (item.goedkoop === "Yes") {
                           kleur = verleden ? "rgba(1,161,128,0.15)" : "rgba(1,161,128,1)";
                         }
                         else if (item.duur === "Yes") {

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1387,6 +1387,8 @@ views:
                 name: Highest Price Periods Tomorrow
               - entity: input_text.dynamic_manual_period_tomorrow
                 name: Manual Periods Tomorrow
+              - entity: sensor.dynamic_next_day_manual_period
+                name: Manual Periods For Tomorrow (calculated)
             visibility:
               - condition: time
                 after: "13:30:00"

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1393,8 +1393,13 @@ views:
                 name: Highest Price Periods Tomorrow
               - entity: input_text.dynamic_manual_period_tomorrow
                 name: Manual Periods Tomorrow
-              - entity: sensor.dynamic_next_day_manual_period
-                name: Manual Periods For Tomorrow (calculated)
+              - type: conditional
+                conditions:
+                  - entity: sensor.dynamic_next_day_manual_period
+                    state_not: ""
+                row:
+                  entity: sensor.dynamic_next_day_manual_period
+                  name: Manual Periods For Tomorrow (calculated)
             visibility:
               - condition: time
                 after: "13:30:00"

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -91,13 +91,19 @@ input_text:
   dynamic_manual_period:
     name: Dynamic Manual Period
     icon: mdi:view-grid
-    max: 250
+    max: 255
     mode: text
 
   dynamic_manual_period_tomorrow:
     name: Dynamic Manual Period Tomorrow
     icon: mdi:view-grid
-    max: 250
+    max: 255
+    mode: text
+
+  dynamic_manual_period_next:
+    name: Dynamic Manual Period Next Day
+    icon: mdi:view-grid-outline
+    max: 255
     mode: text
 
 input_number:
@@ -621,6 +627,279 @@ template:
               0
             {% endif %}
 
+      - name: "Dynamic Period Planning"
+        unique_id: dynamic_period_planning
+        icon: mdi:calendar-clock
+        state: >-
+          {{ 'Yes' if state_attr('sensor.dynamic_nordpool', 'raw_today') else 'No' }}
+        attributes:
+          selection: >-
+            {%- macro zen_parse(txt) -%}
+              {%- set ns = namespace(items=[]) -%}
+              {%- for deel in txt.split(';') -%}
+                {%- set t = deel | trim | replace(' ', '') | upper -%}
+                {%- if t | length > 0 -%}
+                  {%- if t | regex_match('^\+?Z[GD]?[0-9]{1,2}:[0-9]{2}-[0-9]{1,2}:[0-9]{2}V?$') -%}
+                    {%- set plus = t[0] == '+' -%}
+                    {%- set b1 = t[1:] if plus else t -%}
+                    {%- set vast = b1[-1] == 'V' -%}
+                    {%- set b2 = b1[:-1] if vast else b1 -%}
+                    {%- set kind = b2[1] if b2[1] in ['G', 'D'] else 'B' -%}
+                    {%- set rng = (b2[1:] if kind == 'B' else b2[2:]).split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = '%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1]) -%}
+                    {%- set ns.items = ns.items + [{'k': 'z', 'kind': kind, 'a': a, 'b': b, 'nd': (plus or b <= a), 'vast': vast, 'tok': t}] -%}
+                  {%- elif t | regex_match('^[+-][GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                    {%- set rng = t[2:].split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                    {%- set ns.items = ns.items + [{'k': 'm', 'sign': t[0], 'type': t[1], 'a': a, 'b': b, 'tok': t}] -%}
+                  {%- elif t | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                    {%- set rng = t[1:].split('-') -%}
+                    {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                    {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                    {%- set ns.items = ns.items + [{'k': 'a', 'type': t[0], 'a': a, 'b': b, 'tok': t}] -%}
+                  {%- else -%}
+                    {%- set ns.items = ns.items + [{'k': 'x', 'tok': t}] -%}
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {{- ns.items | to_json -}}
+            {%- endmacro -%}
+            {%- macro zen_plan(eigen, extra, P, n_g, n_d, slot_delta) -%}
+              {%- if eigen | count == 0 -%}
+                {{- {'g': [], 'd': []} | to_json -}}
+              {%- else -%}
+                {%- set basis = eigen[0].start | as_datetime -%}
+                {%- set tz = basis.tzinfo -%}
+                {%- set dag = basis.strftime('%Y-%m-%d') -%}
+                {%- set alle = eigen + extra -%}
+                {%- set ns = namespace(g=[], d=[]) -%}
+                {%- set vaste = P | selectattr('k', 'eq', 'a') | list -%}
+                {%- if vaste | count > 0 -%}
+                  {%- for it in vaste -%}
+                    {%- set s_dt = strptime(dag ~ ' ' ~ it.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                    {%- if it.b -%}
+                      {%- set e0 = strptime(dag ~ ' ' ~ it.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                      {%- set e_dt = (e0 + timedelta(days=1) if e0 <= s_dt else e0) + timedelta(seconds=1) -%}
+                    {%- else -%}
+                      {%- set e_dt = s_dt + slot_delta -%}
+                    {%- endif -%}
+                    {%- for u in eigen -%}
+                      {%- if (u.start | as_datetime) < e_dt and (u.end | as_datetime) > s_dt -%}
+                        {%- if it.type == 'G' -%}
+                          {%- set ns.g = ns.g + [u.start] -%}
+                        {%- else -%}
+                          {%- set ns.d = ns.d + [u.start] -%}
+                        {%- endif -%}
+                      {%- endif -%}
+                    {%- endfor -%}
+                  {%- endfor -%}
+                  {%- set ns.g = ns.g | unique | list -%}
+                  {%- set ns.d = ns.d | unique | list -%}
+                {%- else -%}
+                  {%- set zoek = P | selectattr('k', 'eq', 'z') | list -%}
+                  {%- for soort in ['G', 'D'] -%}
+                    {%- set vensters = zoek | selectattr('kind', 'in', ['B', soort]) | list -%}
+                    {%- set pool = namespace(l=[]) -%}
+                    {%- if vensters | count > 0 -%}
+                      {%- for u in alle -%}
+                        {%- set us = u.start | as_datetime -%}
+                        {%- set raak = namespace(v=false) -%}
+                        {%- for w in vensters -%}
+                          {%- set ws = strptime(dag ~ ' ' ~ w.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                          {%- set w0 = strptime(dag ~ ' ' ~ w.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                          {%- set we = w0 + timedelta(days=1) if w.nd else w0 -%}
+                          {%- if us >= ws and us < we -%}
+                            {%- set raak.v = true -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {%- if raak.v -%}
+                          {%- set pool.l = pool.l + [u] -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+                    {%- else -%}
+                      {%- set pool.l = eigen | list -%}
+                    {%- endif -%}
+                    {%- set gesorteerd = pool.l | sort(attribute='value') | list -%}
+                    {%- if soort == 'G' -%}
+                      {%- set ns.g = (gesorteerd[:n_g] | map(attribute='start') | list) if n_g > 0 else [] -%}
+                    {%- else -%}
+                      {%- set ns.d = (gesorteerd[-n_d:] | map(attribute='start') | list) if n_d > 0 else [] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                {%- endif -%}
+                {%- for it in P if it.k == 'm' -%}
+                  {%- set s_dt = strptime(dag ~ ' ' ~ it.a, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                  {%- if it.b -%}
+                    {%- set e0 = strptime(dag ~ ' ' ~ it.b, '%Y-%m-%d %H:%M').replace(tzinfo=tz) -%}
+                    {%- set e_dt = (e0 + timedelta(days=1) if e0 <= s_dt else e0) + timedelta(seconds=1) -%}
+                  {%- else -%}
+                    {%- set e_dt = s_dt + slot_delta -%}
+                  {%- endif -%}
+                  {%- set tr = namespace(l=[]) -%}
+                  {%- for u in eigen -%}
+                    {%- if (u.start | as_datetime) < e_dt and (u.end | as_datetime) > s_dt -%}
+                      {%- set tr.l = tr.l + [u.start] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                  {%- if it.sign == '+' -%}
+                    {%- if it.type == 'G' -%}
+                      {%- set ns.g = (ns.g + tr.l) | unique | list -%}
+                      {%- set ns.d = ns.d | reject('in', tr.l) | list -%}
+                    {%- else -%}
+                      {%- set ns.d = (ns.d + tr.l) | unique | list -%}
+                      {%- set ns.g = ns.g | reject('in', tr.l) | list -%}
+                    {%- endif -%}
+                  {%- else -%}
+                    {%- if it.type == 'G' -%}
+                      {%- set ns.g = ns.g | reject('in', tr.l) | list -%}
+                    {%- else -%}
+                      {%- set ns.d = ns.d | reject('in', tr.l) | list -%}
+                    {%- endif -%}
+                  {%- endif -%}
+                {%- endfor -%}
+                {{- {'g': ns.g, 'd': ns.d} | to_json -}}
+              {%- endif -%}
+            {%- endmacro -%}
+            {%- set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') -%}
+            {%- set slot_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) -%}
+            {%- set vandaag = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set tv = states('input_text.dynamic_manual_period') -%}
+            {%- set tm = states('input_text.dynamic_manual_period_tomorrow') -%}
+            {%- set tv = '' if tv in ['unknown', 'unavailable'] else tv -%}
+            {%- set tm = '' if tm in ['unknown', 'unavailable'] else tm -%}
+            {%- set plan_v = zen_plan(vandaag, morgen, zen_parse(tv) | from_json,
+                states('input_number.dynamic_lowest_price_x_period') | int(0), states('input_number.dynamic_highest_price_x_period') | int(0), slot_delta) | from_json -%}
+            {%- set plan_m = zen_plan(morgen, [], zen_parse(tm) | from_json,
+                states('input_number.dynamic_lowest_price_x_period_tomorrow') | int(0), states('input_number.dynamic_highest_price_x_period_tomorrow') | int(0), slot_delta) | from_json -%}
+            {%- set vs = vandaag | map(attribute='start') | list -%}
+            {{- {'tg': plan_v.g | select('in', vs) | list,
+                 'td': plan_v.d | select('in', vs) | list,
+                 'cg': plan_v.g | reject('in', vs) | list,
+                 'cd': plan_v.d | reject('in', vs) | list,
+                 'mg': plan_m.g,
+                 'md': plan_m.d} | to_json -}}
+
+      - name: "Dynamic Next Day Manual Period"
+        unique_id: dynamic_next_day_manual_period
+        icon: mdi:calendar-arrow-right
+        state: >-
+          {%- macro zen_parse(txt) -%}
+            {%- set ns = namespace(items=[]) -%}
+            {%- for deel in txt.split(';') -%}
+              {%- set t = deel | trim | replace(' ', '') | upper -%}
+              {%- if t | length > 0 -%}
+                {%- if t | regex_match('^\+?Z[GD]?[0-9]{1,2}:[0-9]{2}-[0-9]{1,2}:[0-9]{2}V?$') -%}
+                  {%- set plus = t[0] == '+' -%}
+                  {%- set b1 = t[1:] if plus else t -%}
+                  {%- set vast = b1[-1] == 'V' -%}
+                  {%- set b2 = b1[:-1] if vast else b1 -%}
+                  {%- set kind = b2[1] if b2[1] in ['G', 'D'] else 'B' -%}
+                  {%- set rng = (b2[1:] if kind == 'B' else b2[2:]).split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = '%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1]) -%}
+                  {%- set ns.items = ns.items + [{'k': 'z', 'kind': kind, 'a': a, 'b': b, 'nd': (plus or b <= a), 'vast': vast, 'tok': t}] -%}
+                {%- elif t | regex_match('^[+-][GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                  {%- set rng = t[2:].split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                  {%- set ns.items = ns.items + [{'k': 'm', 'sign': t[0], 'type': t[1], 'a': a, 'b': b, 'tok': t}] -%}
+                {%- elif t | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') -%}
+                  {%- set rng = t[1:].split('-') -%}
+                  {%- set a = '%02d:%s' % (rng[0].split(':')[0] | int, rng[0].split(':')[1]) -%}
+                  {%- set b = ('%02d:%s' % (rng[1].split(':')[0] | int, rng[1].split(':')[1])) if rng | count > 1 else none -%}
+                  {%- set ns.items = ns.items + [{'k': 'a', 'type': t[0], 'a': a, 'b': b, 'tok': t}] -%}
+                {%- else -%}
+                  {%- set ns.items = ns.items + [{'k': 'x', 'tok': t}] -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {{- ns.items | to_json -}}
+          {%- endmacro -%}
+          {%- macro zen_overdracht(morgen, cg, cd, ns) -%}
+            {%- set g = namespace(type='', first='', last='', end='') -%}
+            {%- for u in morgen | sort(attribute='start') -%}
+              {%- set soort = 'G' if u.start in cg else ('D' if u.start in cd else '') -%}
+              {%- if soort != '' and g.type == soort and g.end == u.start -%}
+                {%- set g.last = u.start -%}
+                {%- set g.end = u.end -%}
+              {%- else -%}
+                {%- if g.type != '' -%}
+                  {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+                {%- endif -%}
+                {%- set g.type = soort -%}
+                {%- set g.first = u.start -%}
+                {%- set g.last = u.start -%}
+                {%- set g.end = u.end -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {%- if g.type != '' -%}
+              {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+            {%- endif -%}
+          {%- endmacro -%}
+          {%- set morgen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+          {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+          {%- set tv = states('input_text.dynamic_manual_period') -%}
+          {%- set tm = states('input_text.dynamic_manual_period_tomorrow') -%}
+          {%- set tv = '' if tv in ['unknown', 'unavailable'] else tv -%}
+          {%- set tm = '' if tm in ['unknown', 'unavailable'] else tm -%}
+          {%- set pv = zen_parse(tv) | from_json -%}
+          {%- set pm = zen_parse(tm) | from_json -%}
+          {%- set vast = pv | selectattr('k', 'eq', 'z') | selectattr('vast') | list -%}
+          {%- set vaste_soorten = vast | map(attribute='kind') | list -%}
+          {%- set ns = namespace(tok=[]) -%}
+          {%- for it in vast -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- for it in pm if it.k == 'z' and it.kind not in vaste_soorten -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- for it in pm if it.k in ['a', 'x'] -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {{- zen_overdracht(morgen, sel.get('cg', []), sel.get('cd', []), ns) -}}
+          {%- for it in pm if it.k == 'm' -%}
+            {%- set ns.tok = ns.tok + [it.tok] -%}
+          {%- endfor -%}
+          {%- set res = namespace(s='') -%}
+          {%- for t in ns.tok -%}
+            {%- set kandidaat = res.s ~ (';' if res.s | length > 0 else '') ~ t -%}
+            {%- if kandidaat | length <= 255 -%}
+              {%- set res.s = kandidaat -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{- res.s -}}
+        attributes:
+          carry_periods: >-
+            {%- macro zen_overdracht(morgen, cg, cd, ns) -%}
+              {%- set g = namespace(type='', first='', last='', end='') -%}
+              {%- for u in morgen | sort(attribute='start') -%}
+                {%- set soort = 'G' if u.start in cg else ('D' if u.start in cd else '') -%}
+                {%- if soort != '' and g.type == soort and g.end == u.start -%}
+                  {%- set g.last = u.start -%}
+                  {%- set g.end = u.end -%}
+                {%- else -%}
+                  {%- if g.type != '' -%}
+                    {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+                  {%- endif -%}
+                  {%- set g.type = soort -%}
+                  {%- set g.first = u.start -%}
+                  {%- set g.last = u.start -%}
+                  {%- set g.end = u.end -%}
+                {%- endif -%}
+              {%- endfor -%}
+              {%- if g.type != '' -%}
+                {%- set ns.tok = ns.tok + ['+' ~ g.type ~ g.first[11:16] ~ ('' if g.first == g.last else '-' ~ g.last[11:16])] -%}
+              {%- endif -%}
+            {%- endmacro -%}
+            {%- set morgen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set ns = namespace(tok=[]) -%}
+            {{- zen_overdracht(morgen, sel.get('cg', []), sel.get('cd', []), ns) -}}
+            {{- ns.tok | join(';') -}}
+
       - name: "Dynamic Spread Indication"
         unique_id: dynamic_spread_indication
         icon: mdi:percent-box
@@ -639,7 +918,15 @@ template:
           {% endif %}
         attributes:
           manual_periods: >
-            {% if states('input_text.dynamic_manual_period') | length > 0 %}
+            {% set txt = states('input_text.dynamic_manual_period') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
@@ -722,7 +1009,15 @@ template:
           {% endif %}
         attributes:
           manual_periods: >
-            {% if states('input_text.dynamic_manual_period') | length > 0 %}
+            {% set txt = states('input_text.dynamic_manual_period') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
@@ -797,7 +1092,15 @@ template:
           {% endif %}
         attributes:
           manual_periods: >
-            {% if states('input_text.dynamic_manual_period_tomorrow') | length > 0 %}
+            {% set txt = states('input_text.dynamic_manual_period_tomorrow') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
@@ -878,7 +1181,15 @@ template:
           {% endif %}
         attributes:
           manual_periods: >
-            {% if states('input_text.dynamic_manual_period_tomorrow') | length > 0 %}
+            {% set txt = states('input_text.dynamic_manual_period_tomorrow') %}
+            {% set txt = '' if txt in ['unknown', 'unavailable'] else txt %}
+            {% set nsv = namespace(vast=false) %}
+            {% for deel in txt.split(';') %}
+              {% if (deel | trim | replace(' ', '') | upper) | regex_match('^[GD][0-9]{1,2}:[0-9]{2}(-[0-9]{1,2}:[0-9]{2})?$') %}
+                {% set nsv.vast = true %}
+              {% endif %}
+            {% endfor %}
+            {% if nsv.vast %}
               n.v.t.
             {% else %}
               {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_tomorrow') or [] %}
@@ -938,363 +1249,120 @@ template:
       - name: "Dynamic Highest Price Period"
         unique_id: dynamic_highest_price_period
         icon: mdi:progress-clock
-        state: >
-          {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
-          {% set handmatige = states('input_text.dynamic_manual_period') %}
-          {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
-          {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
-          {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-          {% if prijzen is iterable %}
-            {% set ns = namespace(dure_starttijden=[]) %}
-            {% if handmatige | length > 0 %}
-              {% for item in handmatige.split(';') %}
-                {% if item[0] == 'D' %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-              {% endfor %}
-            {% else %}
-              {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-              {% if aantal_duur > 0 %}
-                {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-              {% else %}
-                {% set ns.dure_starttijden = [] %}
-              {% endif %}
-            {% endif %}
-            {% set nu = now().astimezone() %}
-            {% set actief = prijzen
-              | selectattr('start', 'in', ns.dure_starttijden)
+        state: >-
+          {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') -%}
+          {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+          {%- if prijzen is iterable -%}
+            {%- set gekozen = sel.get('td', []) -%}
+            {%- set nu = now().astimezone() -%}
+            {%- set actief = prijzen
+              | selectattr('start', 'in', gekozen)
               | selectattr('start', 'le', nu.isoformat())
               | selectattr('end', 'gt', nu.isoformat())
-              | list %}
-            {{ 'Yes' if actief | length > 0 else 'No' }}
-          {% else %}
-            Onbekend
-          {% endif %}
+              | list -%}
+            {{- 'Yes' if actief | length > 0 else 'No' -}}
+          {%- else -%}
+            {{- 'Onbekend' -}}
+          {%- endif -%}
         attributes:
-          raw_today: >
-            {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') %}
-            {% set handmatige = states('input_text.dynamic_manual_period') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goede_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% for uur in prijzen %}
-                    {% if uur.start[11:16] == tijden %}
-                      {% if type == 'G' %}
-                        {% set ns.goede_starttijden = ns.goede_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goede_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'Yes' if uur.start in ns.goede_starttijden else 'No' }}",
-                  "duur": "{{ 'Yes' if uur.start in ns.dure_starttijden else 'No' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
+          raw_today: >-
+            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('Yes' if uur.start in g else 'No'),
+                  'duur': ('Yes' if uur.start in d else 'No')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
 
       - name: "Dynamic Lowest Price Period"
         unique_id: dynamic_lowest_price_period
         icon: mdi:progress-clock
-        state: >
-          {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
-          {% set handmatige = states('input_text.dynamic_manual_period') %}
-          {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
-          {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
-          {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-          {% if prijzen is iterable %}
-            {% set ns = namespace(goedkope_starttijden=[]) %}
-            {% if handmatige | length > 0 %}
-              {% for item in handmatige.split(';') %}
-                {% if item[0] == 'G' %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                    {% endif %}
-                  {% endfor %}
-                {% endif %}
-              {% endfor %}
-            {% else %}
-              {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-              {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-            {% endif %}
-            {% set nu = now().astimezone() %}
-            {% set in_goedkoop_blok = prijzen
-              | selectattr('start', 'in', ns.goedkope_starttijden)
+        state: >-
+          {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') -%}
+          {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+          {%- if prijzen is iterable -%}
+            {%- set gekozen = sel.get('tg', []) -%}
+            {%- set nu = now().astimezone() -%}
+            {%- set actief = prijzen
+              | selectattr('start', 'in', gekozen)
               | selectattr('start', 'le', nu.isoformat())
               | selectattr('end', 'gt', nu.isoformat())
-              | list %}
-            {{ 'Yes' if in_goedkoop_blok | length > 0 else 'No' }}
-          {% else %}
-            Onbekend
-          {% endif %}
+              | list -%}
+            {{- 'Yes' if actief | length > 0 else 'No' -}}
+          {%- else -%}
+            {{- 'Onbekend' -}}
+          {%- endif -%}
         attributes:
-          raw_today: >
-            {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
-            {% set handmatige = states('input_text.dynamic_manual_period') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
-            {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
-            {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goedkope_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% if type == 'G' %}
-                        {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'Yes' if uur.start in ns.goedkope_starttijden else 'No' }}",
-                  "duur": "{{ 'Yes' if uur.start in ns.dure_starttijden else 'No' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-          raw_tomorrow: >
-            {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') %}
-            {% set handmatige = states('input_text.dynamic_manual_period_tomorrow') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period_tomorrow') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period_tomorrow') | int %}
-            {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
-            {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
-            {% if prijzen is iterable %}
-              {% set ns = namespace(goedkope_starttijden=[], dure_starttijden=[]) %}
-              {% if handmatige | length > 0 %}
-                {% for item in handmatige.split(';') %}
-                  {% set type = item[0] %}
-                  {% set tijden = item[1:] %}
-                  {% if '-' in tijden %}
-                    {% set start_str = tijden.split('-')[0] %}
-                    {% set eind_str = tijden.split('-')[1] %}
-                    {% set range_block = True %}
-                  {% else %}
-                    {% set start_str = tijden %}
-                    {% set range_block = False %}
-                  {% endif %}
-                  {% for uur in prijzen %}
-                    {% set dt_start = uur.start | as_datetime %}
-                    {% set dt_end = uur.end | as_datetime %}
-                    {% set dag = dt_start.strftime('%Y-%m-%d') %}
-                    {% set tz = dt_start.tzinfo %}
-                    {% set start_dt = strptime(dag ~ ' ' ~ start_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                    {% if range_block %}
-                      {% set eind_dt = strptime(dag ~ ' ' ~ eind_str, '%Y-%m-%d %H:%M').replace(tzinfo=tz) %}
-                      {% if eind_dt <= start_dt %}
-                        {% set eind_dt = eind_dt + timedelta(days=1) %}
-                      {% endif %}
-                      {% set eind_dt = eind_dt + timedelta(seconds=1) %}
-                    {% else %}
-                      {% set eind_dt = start_dt + default_delta %}
-                    {% endif %}
-                    {% if dt_start < eind_dt and dt_end > start_dt %}
-                      {% if type == 'G' %}
-                        {% set ns.goedkope_starttijden = ns.goedkope_starttijden + [uur.start] %}
-                      {% elif type == 'D' %}
-                        {% set ns.dure_starttijden = ns.dure_starttijden + [uur.start] %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-                {% endfor %}
-              {% else %}
-                {% set prijzen_sorted = prijzen | sort(attribute='value') %}
-                {% set ns.goedkope_starttijden = prijzen_sorted[:aantal_goedkoop] | map(attribute='start') | list %}
-                {% if aantal_duur > 0 %}
-                  {% set ns.dure_starttijden = prijzen_sorted[-aantal_duur:] | map(attribute='start') | list %}
-                {% else %}
-                  {% set ns.dure_starttijden = [] %}
-                {% endif %}
-              {% endif %}
-              [
-              {% for uur in prijzen %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ 'Yes' if uur.start in ns.goedkope_starttijden else 'No' }}",
-                  "duur": "{{ 'Yes' if uur.start in ns.dure_starttijden else 'No' }}"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-          duurste_na_eerste_goedkope: >
-            {% set prijzen = state_attr('sensor.dynamic_lowest_price_period','raw_today') or [] %}
-            {% set goedkope = prijzen
-              | selectattr('goedkoop','eq','Yes')
+          raw_today: >-
+            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('Yes' if uur.start in g else 'No'),
+                  'duur': ('Yes' if uur.start in d else 'No')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          raw_tomorrow: >-
+            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('mg', []) -%}
+            {%- set d = sel.get('md', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in prijzen -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': ('Yes' if uur.start in g else 'No'),
+                  'duur': ('Yes' if uur.start in d else 'No')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope: >-
+            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) -%}
+            {%- set d = sel.get('td', []) -%}
+            {%- set goedkope = prijzen
+              | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
               | select('!=', None)
               | sort
-              | list %}
-            {% set eerste_goedkoop = goedkope | first if goedkope else none %}
-            {% if prijzen and eerste_goedkoop %}
-              [
-              {% for uur in prijzen
-                if uur.duur == 'Yes'
-                and (uur.start | as_datetime > eerste_goedkoop)
-              %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ uur.goedkoop }}",
-                  "duur": "Yes"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
-
-          duurste_na_eerste_goedkope_tomorrow: >
-            {% set prijzen = state_attr('sensor.dynamic_lowest_price_period','raw_tomorrow') or [] %}
-            {% set goedkope = prijzen
-              | selectattr('goedkoop','eq','Yes')
+              | list -%}
+            {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- if prijzen and eerste_goedkoop -%}
+              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+                {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                    'goedkoop': ('Yes' if uur.start in g else 'No'), 'duur': 'Yes'}] -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope_tomorrow: >-
+            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('mg', []) -%}
+            {%- set d = sel.get('md', []) -%}
+            {%- set goedkope = prijzen
+              | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
               | select('!=', None)
               | sort
-              | list %}
-            {% set eerste_goedkoop = goedkope | first if goedkope else none %}
-            {% if prijzen and eerste_goedkoop %}
-              [
-              {% for uur in prijzen
-                if uur.duur == 'Yes'
-                and (uur.start | as_datetime > eerste_goedkoop)
-              %}
-                {
-                  "start": "{{ uur.start }}",
-                  "end": "{{ uur.end }}",
-                  "value": {{ uur.value }},
-                  "goedkoop": "{{ uur.goedkoop }}",
-                  "duur": "Yes"
-                }{% if not loop.last %},{% endif %}
-              {% endfor %}
-              ]
-            {% else %}
-              []
-            {% endif %}
+              | list -%}
+            {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- if prijzen and eerste_goedkoop -%}
+              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+                {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                    'goedkoop': ('Yes' if uur.start in g else 'No'), 'duur': 'Yes'}] -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {{- ns.l | to_json -}}
 
       - name: "Zendure Export Efficiency"
         unique_id: zendure_export_efficiency

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -994,11 +994,8 @@ template:
         icon: mdi:percent-box
         unit_of_measurement: "%"
         state: >
-          {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
-          {% set duurste = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
-
-          {% set goedkope_uren = uren | selectattr('goedkoop','equalto','Yes') | list %}
-          {% set dure_uren = duurste | list %}
+          {% set goedkope_uren = state_attr('sensor.dynamic_lowest_price_period', 'goedkope_in_venster') or [] %}
+          {% set dure_uren = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
 
           {% if goedkope_uren | count > 0 and dure_uren | count > 0 %}
             {% set avg_goedkoop = goedkope_uren | map(attribute='value') | sum / goedkope_uren | count %}
@@ -1032,26 +1029,28 @@ template:
               {{ ns.result | join(';') }}
             {% endif %}
           lowest_price_periods: >
-            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
-            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | sort(attribute='start') | list %}
+            {% set vandaag = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] %}
+            {% set basisdag = (vandaag | first).start[:10] if vandaag | count > 0 else '' %}
+            {% set goedkoop = (state_attr('sensor.dynamic_lowest_price_period', 'goedkope_in_venster') or []) | sort(attribute='start') | list %}
             [
             {% for uur in goedkoop %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }}{{ ' (+1)' if basisdag != '' and uur.start[:10] != basisdag else '' }} - €{{ '%.4f' | format(uur.value) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
           highest_price_periods: >
-            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
-            {% set duur = uren | sort(attribute='value', reverse=true) | list %}
+            {% set vandaag = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] %}
+            {% set basisdag = (vandaag | first).start[:10] if vandaag | count > 0 else '' %}
+            {% set duur = state_attr('sensor.dynamic_lowest_price_period', 'duurste_na_eerste_goedkope') or [] %}
+            {% set duur = duur | sort(attribute='value', reverse=true) | list %}
             [
             {% for uur in duur %}
-              "{{ (uur.start | as_datetime).strftime('%H:%M') }} - €{{ '%.4f' | format(uur.value) }}"
+              "{{ (uur.start | as_datetime).strftime('%H:%M') }}{{ ' (+1)' if basisdag != '' and uur.start[:10] != basisdag else '' }} - €{{ '%.4f' | format(uur.value) }}"
               {% if not loop.last %}, {% endif %}
             {% endfor %}
             ]
           average_lowest_price: >
-            {% set uren = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
-            {% set goedkoop = uren | selectattr('goedkoop','equalto','Yes') | list %}
+            {% set goedkoop = state_attr('sensor.dynamic_lowest_price_period', 'goedkope_in_venster') or [] %}
             {% if goedkoop | count > 0 %}
               €{{ '%.4f' % (goedkoop | map(attribute='value') | sum / goedkoop | count) }}
             {% else %}
@@ -1321,12 +1320,26 @@ template:
                   'duur': ('Yes' if uur.start in d else 'No')}] -%}
             {%- endfor -%}
             {{- ns.l | to_json -}}
-          duurste_na_eerste_goedkope: >-
-            {%- set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+          goedkope_in_venster: >-
+            {%- set vandaag = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
             {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
-            {%- set g = sel.get('tg', []) -%}
-            {%- set d = sel.get('td', []) -%}
-            {%- set goedkope = prijzen
+            {%- set g = sel.get('tg', []) + sel.get('cg', []) -%}
+            {%- set d = sel.get('td', []) + sel.get('cd', []) -%}
+            {%- set ns = namespace(l=[]) -%}
+            {%- for uur in vandaag + morgen if uur.start in g -%}
+              {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
+                  'goedkoop': 'Yes', 'duur': ('Yes' if uur.start in d else 'No')}] -%}
+            {%- endfor -%}
+            {{- ns.l | to_json -}}
+          duurste_na_eerste_goedkope: >-
+            {%- set vandaag = state_attr('sensor.dynamic_nordpool', 'raw_today') or [] -%}
+            {%- set morgen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') or [] -%}
+            {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
+            {%- set g = sel.get('tg', []) + sel.get('cg', []) -%}
+            {%- set d = sel.get('td', []) + sel.get('cd', []) -%}
+            {%- set venster = vandaag + morgen -%}
+            {%- set goedkope = venster
               | selectattr('start', 'in', g)
               | map(attribute='start')
               | map('as_datetime')
@@ -1335,8 +1348,8 @@ template:
               | list -%}
             {%- set eerste_goedkoop = goedkope | first if goedkope else none -%}
             {%- set ns = namespace(l=[]) -%}
-            {%- if prijzen and eerste_goedkoop -%}
-              {%- for uur in prijzen if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
+            {%- if eerste_goedkoop -%}
+              {%- for uur in venster if uur.start in d and (uur.start | as_datetime) > eerste_goedkoop -%}
                 {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
                     'goedkoop': ('Yes' if uur.start in g else 'No'), 'duur': 'Yes'}] -%}
               {%- endfor -%}

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -1313,11 +1313,14 @@ template:
             {%- set sel = state_attr('sensor.dynamic_period_planning', 'selection') or {} -%}
             {%- set g = sel.get('mg', []) -%}
             {%- set d = sel.get('md', []) -%}
+            {%- set cg = sel.get('cg', []) -%}
+            {%- set cd = sel.get('cd', []) -%}
             {%- set ns = namespace(l=[]) -%}
             {%- for uur in prijzen -%}
               {%- set ns.l = ns.l + [{'start': uur.start, 'end': uur.end, 'value': uur.value,
                   'goedkoop': ('Yes' if uur.start in g else 'No'),
-                  'duur': ('Yes' if uur.start in d else 'No')}] -%}
+                  'duur': ('Yes' if uur.start in d else 'No'),
+                  'overdracht': ('G' if uur.start in cg else ('D' if uur.start in cd else ''))}] -%}
             {%- endfor -%}
             {{- ns.l | to_json -}}
           goedkope_in_venster: >-

--- a/README.md
+++ b/README.md
@@ -131,6 +131,61 @@ Go to the explanation of all modes
 
 ---
 
+## 🕘 Dynamic Manual Periods
+
+In the dynamic modes the automation searches for the cheapest and the most expensive periods of the day. A period is one hour, or 15 minutes when **Dynamic 15 Minute Interval** is switched on. With **Dynamic Manual Period** (`input_text.dynamic_manual_period`) and **Dynamic Manual Period Tomorrow** (`input_text.dynamic_manual_period_tomorrow`) you steer that search yourself. Entries are separated by `;`, times are written as `HH:MM`, and the input is not case sensitive.
+
+### 1. Fixed periods — replaces the automatic search
+
+| Example | Meaning |
+|-|-|
+| `G11:00` | 11:00 is a cheap period |
+| `D12:00` | 12:00 is an expensive period |
+| `G11:00-13:00` | 11:00 up to and including 13:00 are cheap periods |
+| `G11:00;D12:00;G15:00` | a combination of single periods |
+
+As soon as one fixed entry is present, the automatic search is switched off completely for that day: only the periods you listed yourself are used.
+
+### 2. Modifiers `+` and `-` — adjusts the automatic search
+
+Put `+` or `-` in front of an entry to change the calculated result instead of replacing it.
+
+| Example | Meaning |
+|-|-|
+| `+D02:00` | mark 02:00 as expensive as well |
+| `+G18:00-20:00` | mark 18:00 up to and including 20:00 as cheap as well |
+| `-G03:00` | remove 03:00 from the cheap periods |
+| `-D14:00-16:00` | remove 14:00 up to and including 16:00 from the expensive periods |
+
+A `+` always wins: a period that was calculated as cheap becomes expensive with `+D`, and the other way round. A `-` only removes a period of the type you mention, so `-G` on a period that is in fact expensive does nothing. Modifiers are applied in the order in which you write them, and they also work together with fixed periods.
+
+### 3. Search windows `Z`, `ZG` and `ZD`
+
+By default the search runs over the day itself. With a search window you decide where the automation is allowed to look. A search window always uses a time **range** (single periods are not allowed) and has to be placed at the beginning of the text field. Several windows may be combined; the automation then searches in all of them.
+
+| Example | Meaning |
+|-|-|
+| `Z10:00-16:00` | search cheap *and* expensive periods between 10:00 and 16:00 |
+| `ZG22:00-06:00` | search cheap periods from 22:00 until 06:00 the next day |
+| `ZD14:00-13:00` | search expensive periods from 14:00 until 13:00 the next day |
+| `+Z10:00-13:00` | search from 10:00 today until 13:00 tomorrow |
+
+The window runs into the next day when the end time is smaller than or equal to the start time, or when you put a `+` in front of the window. That is what makes it possible to find the real night peak, which otherwise falls apart at midnight. As long as tomorrow's prices have not been published yet — and always for **Dynamic Manual Period Tomorrow** — the search simply stops at the end of the available prices.
+
+Add `V` (*vast*, fixed) to keep a window when the settings of tomorrow move into today at midnight, for example `ZD14:00-13:00V`.
+
+> Search windows only steer the automatic search. If the same field also contains a fixed period (chapter 1) the automatic search is off, and the window has no effect.
+
+### 4. What happens at midnight
+
+Shortly before midnight the automation calculates the manual period for the new day and shows it in **Dynamic Next Day Manual Period**. At 00:00 that value is written into **Dynamic Manual Period**:
+
+* the entries of **Dynamic Manual Period Tomorrow** are taken over;
+* a window marked with `V` in today's field is kept and replaces the window of the same type (`Z`, `ZG` or `ZD`) that came from tomorrow;
+* every period of tomorrow that was selected by today's multi-day search window is added as a modifier, for example `+G00:00-02:00;+D09:00`, so that a plan made across midnight is really carried out.
+
+---
+
 ## 🔃 (Optional) Plug-N-Play Dashboard
 
 You can now also directly use a fully plug-n-play dashboard:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Shortly before midnight the automation calculates the manual period for the new 
 * a window marked with `V` in today's field is kept and replaces the window of the same type (`Z`, `ZG` or `ZD`) that came from tomorrow;
 * every period of tomorrow that was selected by today's multi-day search window is added as a modifier, for example `+G00:00-02:00;+D09:00`, so that a plan made across midnight is really carried out.
 
+Those carried periods are drawn on the **Dynamic Tomorrow** chart in a lighter tone of the same colour, because they come from today's plan and not from tomorrow's own calculation. A period claimed by both is drawn in the lighter tone: today's window is what actually ends up in the field at midnight.
+
 ---
 
 ## 🔃 (Optional) Plug-N-Play Dashboard

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Add `V` (*vast*, fixed) to keep a window when the settings of tomorrow move into
 
 > Search windows only steer the automatic search. If the same field also contains a fixed period (chapter 1) the automatic search is off, and the window has no effect.
 
+**Dynamic Spread Indication DSC** follows the window. It compares the cheap periods of the plan against the expensive periods that come *after* the first cheap one, and counts the periods a multi-day window picked up on the next day as well; those are shown with a `(+1)` suffix. Expensive periods lying before the first cheap period stay excluded — that is what this sensor measures, and it is the value the dynamic charging automation checks against **Dynamic Minimal Spread**.
+
 ### 4. What happens at midnight
 
 Shortly before midnight the automation calculates the manual period for the new day and shows it in **Dynamic Next Day Manual Period**. At 00:00 that value is written into **Dynamic Manual Period**:

--- a/README.nl.md
+++ b/README.nl.md
@@ -124,6 +124,61 @@ Ga naar de uitleg over alle verschillende modussen
 
 ---
 
+## 🕘 Dynamische handmatige periodes
+
+In de dynamische modussen zoekt de automatisering naar de goedkoopste en de duurste periodes van de dag. Een periode is één uur, of 15 minuten wanneer **Dynamisch 15 Minuten** aanstaat. Met **Dynamisch Handmatige Periode** (`input_text.dynamisch_handmatige_periode`) en **Dynamisch Handmatige Periode Morgen** (`input_text.dynamisch_handmatige_periode_morgen`) stuur je die zoekopdracht zelf. Onderdelen worden gescheiden door `;`, tijden schrijf je als `UU:MM` en hoofdletters maken niet uit.
+
+### 1. Vaste periodes — vervangt de automatische berekening
+
+| Voorbeeld | Betekenis |
+|-|-|
+| `G11:00` | 11:00 is een goedkope periode |
+| `D12:00` | 12:00 is een dure periode |
+| `G11:00-13:00` | 11:00 tot en met 13:00 zijn goedkope periodes |
+| `G11:00;D12:00;G15:00` | een combinatie van losse periodes |
+
+Zodra er één vaste periode in het veld staat, wordt de automatische berekening voor die dag volledig uitgezet: alleen de periodes die je zelf hebt opgegeven worden gebruikt.
+
+### 2. Aanpassingen `+` en `-` — past de automatische berekening aan
+
+Zet `+` of `-` vóór een onderdeel om het berekende resultaat aan te passen in plaats van te vervangen.
+
+| Voorbeeld | Betekenis |
+|-|-|
+| `+D02:00` | markeer 02:00 óók als duur |
+| `+G18:00-20:00` | markeer 18:00 tot en met 20:00 óók als goedkoop |
+| `-G03:00` | haal 03:00 weg bij de goedkope periodes |
+| `-D14:00-16:00` | haal 14:00 tot en met 16:00 weg bij de dure periodes |
+
+Een `+` wint altijd: een periode die als goedkoop berekend was, wordt met `+D` duur, en andersom. Een `-` verwijdert alleen een periode van het type dat je noemt, dus `-G` op een periode die in werkelijkheid duur is doet niets. Aanpassingen worden verwerkt in de volgorde waarin je ze opschrijft en werken ook samen met vaste periodes.
+
+### 3. Zoekvensters `Z`, `ZG` en `ZD`
+
+Standaard zoekt de automatisering binnen de dag zelf. Met een zoekvenster bepaal je waar er gezocht mag worden. Een zoekvenster gebruikt altijd een **tijdbereik** (losse periodes mogen niet) en moet vooraan in het tekstveld staan. Meerdere vensters mogen gecombineerd worden; er wordt dan in alle vensters gezocht.
+
+| Voorbeeld | Betekenis |
+|-|-|
+| `Z10:00-16:00` | zoek goedkope *én* dure periodes tussen 10:00 en 16:00 |
+| `ZG22:00-06:00` | zoek goedkope periodes van 22:00 tot 06:00 de volgende dag |
+| `ZD14:00-13:00` | zoek dure periodes van 14:00 tot 13:00 de volgende dag |
+| `+Z10:00-13:00` | zoek van vandaag 10:00 tot morgen 13:00 |
+
+Het venster loopt door naar de volgende dag wanneer de eindtijd kleiner is dan of gelijk is aan de begintijd, of wanneer je een `+` vóór het venster zet. Daarmee is het mogelijk om de echte nachtpiek te vinden, die anders om middernacht in tweeën valt. Zolang de prijzen van morgen nog niet bekend zijn — en altijd bij **Dynamisch Handmatige Periode Morgen** — stopt het zoeken gewoon bij het einde van de beschikbare prijzen.
+
+Zet er een `V` (vast) achter om een venster te behouden wanneer om middernacht de instellingen van morgen naar vandaag gaan, bijvoorbeeld `ZD14:00-13:00V`.
+
+> Zoekvensters sturen alleen de automatische berekening. Staat er in hetzelfde veld ook een vaste periode (hoofdstuk 1), dan staat de berekening uit en heeft het venster geen effect.
+
+### 4. Wat er om middernacht gebeurt
+
+Vlak vóór middernacht berekent de automatisering de handmatige periode voor de nieuwe dag en toont die in **Dynamisch Handmatige Periode Volgende Dag**. Om 00:00 wordt die waarde in **Dynamisch Handmatige Periode** gezet:
+
+* de onderdelen van **Dynamisch Handmatige Periode Morgen** worden overgenomen;
+* een venster met `V` uit het veld van vandaag blijft staan en vervangt het venster van hetzelfde type (`Z`, `ZG` of `ZD`) dat van morgen komt;
+* elke periode van morgen die door het meerdaagse zoekvenster van vandaag gekozen is, wordt als aanpassing toegevoegd, bijvoorbeeld `+G00:00-02:00;+D09:00`, zodat een plan dat over middernacht heen gemaakt is ook echt uitgevoerd wordt.
+
+---
+
 ## 🔃 (Optioneel) Plug-N-Play Dashboard
 Vanaf nu is het ook mogelijk om direct een volledig plug-n-play dashboard in gebruik te nemen.
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -169,6 +169,8 @@ Zet er een `V` (vast) achter om een venster te behouden wanneer om middernacht d
 
 > Zoekvensters sturen alleen de automatische berekening. Staat er in hetzelfde veld ook een vaste periode (hoofdstuk 1), dan staat de berekening uit en heeft het venster geen effect.
 
+**Dynamisch Spread Indicatie NOM** volgt het venster. De sensor vergelijkt de goedkope periodes van het plan met de dure periodes die *na* de eerste goedkope periode liggen, en telt daarbij ook de periodes mee die een meerdaags venster op de volgende dag heeft gekozen; die krijgen het achtervoegsel `(+1)`. Dure periodes vóór de eerste goedkope periode blijven buiten beschouwing — dat is nu juist wat deze sensor meet, en het is de waarde waarop de dynamische laadautomatisering controleert tegen **Dynamisch Minimale Spread**.
+
 ### 4. Wat er om middernacht gebeurt
 
 Vlak vóór middernacht berekent de automatisering de handmatige periode voor de nieuwe dag en toont die in **Dynamisch Handmatige Periode Volgende Dag**. Om 00:00 wordt die waarde in **Dynamisch Handmatige Periode** gezet:

--- a/README.nl.md
+++ b/README.nl.md
@@ -179,6 +179,8 @@ Vlak vóór middernacht berekent de automatisering de handmatige periode voor de
 * een venster met `V` uit het veld van vandaag blijft staan en vervangt het venster van hetzelfde type (`Z`, `ZG` of `ZD`) dat van morgen komt;
 * elke periode van morgen die door het meerdaagse zoekvenster van vandaag gekozen is, wordt als aanpassing toegevoegd, bijvoorbeeld `+G00:00-02:00;+D09:00`, zodat een plan dat over middernacht heen gemaakt is ook echt uitgevoerd wordt.
 
+Die overgedragen periodes worden op de grafiek **Dynamisch Morgen** in een lichtere tint van dezelfde kleur getekend, omdat ze uit het plan van vandaag komen en niet uit de eigen berekening van morgen. Een periode die door beide gekozen is, krijgt de lichtere tint: het venster van vandaag is wat om middernacht daadwerkelijk in het veld terechtkomt.
+
 ---
 
 ## 🔃 (Optioneel) Plug-N-Play Dashboard


### PR DESCRIPTION
Fixes #234 

You wrote that "big AI based pull requests wont be merged" so I have little hope, but since the two features proposed are objectively really useful and they works nicely, this is my proposal.
Also, I always offer my changes to upstream, to make it a better tool for everyone.

So...

Currently cheap/expensive timeslots are searched within the 0-24 h range. To find the best hours for discharging (without going into advanced simulations like other integrations do) it would be more than enough to find expensive hours for example between midday and next midday. This would ensure that the battery can actually discharge as intended. As shown in #234 

Mainly useful for dynamic trading with or without NOM.

The result is for example this one:
Today:
<img width="485" height="169" alt="Screenshot 2026-08-24 at 23 28 08" src="https://github.com/user-attachments/assets/b54d68b7-060f-4851-b2db-6f0f49a04f12" />

Tomorrow:
<img width="486" height="166" alt="Screenshot 2026-08-24 at 23 28 31" src="https://github.com/user-attachments/assets/daa722c4-6359-49ba-8f57-ae20291fe6ce" />

The best hours to discharge cross the midnight boundary.

To be able to do this, I tried to make it generic so two steps were needed.

**Modifiers**: an entry prefixed with + or - now adjusts the calculated result instead of replacing it. "+G11:00" / "+D14:00-16:00" force periods into the cheap or expensive set (taking over the calculated type), "-G03:00" drops a period only when it is of the type mentioned.
_This is already a very useful feature on its own, since often what I want is to _modify_ the results of an existing automatic search. This could be interesting even without the inter-day search (below)._

For example, I use ZD14:00-13:45 so that it's searching the expensive hours evening and morning, and cheap hours are searched normally within the day, since they end up midday anyway.

**Search windows**: "Z", "ZG" and "ZD" (zoek, zoek goedkoop, zoek duur) followed by a time range, placed at the start of the field, restrict where the automatic search looks (both chap/expensive types, cheap only, expensive only). The range runs into the next day _when its end is not after its start, or when it is prefixed with "+"_, so a night peak can be found across midnight. Basically the whole summer. Windows are clamped to the end of the available price data, obviously. A trailing "V" ("vast") keeps the search window (no deletion) when tomorrow's settings move into today.

_At 23:59:30 the manual period for the new day is calculated and stored, and at midnight that value is copied into today's field_:  tomorrow's entries, the V-marked windows of today (replacing tomorrow's window of the same type), and every period of tomorrow that today's multi-day search selected, added as + modifiers (this requires the use of modifiers introduced above). The calculation of the best timeslots is also performed any time the number of hours for each type is changed, or when tomorrow's prices become known.

_The calculation of price spread is performed accordingly_ based on  the defined search range, not within the same day.

The price graph for tomorrow marks in a lighter colour the timeslots within a range which starts today. 

All is tested, and it seems to work just fine.

It's a huge code block, but it has no visible impact on CPU consumption, since the search stays super-easy and it's not run continuously.

Your point of view expressed in other PRs or issue tickets ("optimisation belongs to other integrations") does not really apply in full here: 

1) the "+/- modifiers" are a feature which just makes sense, since as soon as you try to add/remove one or two timeslots to a default search results you notice that it becomes really difficult, it's a lot of typing to reproduce the existing timeslots, and also while you do that... they disappear.
This feature can be extracted and proposed as separate PR, it's always useful.

2) the custom-range search is not an optimisation, but just the same useful feature you thought about (dynamic trading, best timeslots), adapted to a more realistic use case, where the "best" involves crossing the day boundary. Also, it ensures that the number of hours chosen is located in timeslots where the battery actually has energy.

Given that the feature is large and I spent quite some time for defining requirements, implementation, tests and later refinements, if it gets merged it should be attributed in the Release Notes, as per standard practice.