### PR TITLE
Fix dashboard "History" tab translation

### DIFF
--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -2183,7 +2183,7 @@ views:
   - type: sections
     max_columns: 3
     path: geschiedenis
-    title: Geschiedenis
+    title: History
     icon: mdi:history
     sections:
       - type: grid


### PR DESCRIPTION
Hi everyone,

I'm giving Zendure-HA-zenSDK a try right now. I can't wait to see this evening how well it handles zero import.

I just noticed that the dashboard's "History" tab isn't translated into English.
<img width="132" height="102" alt="image" src="https://github.com/user-attachments/assets/081d4b2e-a367-4771-b4f8-867fe015381b" />


Best regards,