### PR TITLE
Conditionally show PV Export Mode on the health dashboard

### DIFF
--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1424,8 +1424,13 @@ views:
                 name: Error
               - entity: sensor.zendure_2400_ac_offgrid_modus
                 name: Offgrid Modus
-              - entity: sensor.zendure_2400_ac_pv_export_modus
-                name: PV Export Modus
+              - type: conditional
+                conditions:
+                  - entity: input_boolean.pv_tonen_op_dashboard
+                    state: 'on'
+                row:
+                  entity: sensor.zendure_2400_ac_pv_export_modus
+                  name: PV Export Modus
               - entity: sensor.zendure_2400_ac_kalibreren
                 name: Kalibreren
               - entity: sensor.zendure_2400_ac_omvormer_max_oplaadvermogen

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -2669,6 +2669,11 @@ views:
                   target:
                     entity_id: input_button.zendure_2400_ac_advies_instellingen_overnemen
                   data: {}
+                  confirmation:
+                    title: "Standaardinstellingen herstellen ?"
+                    text: "Je huidige instellingen gaan verloren en worden vervangen door de standaardinstellingen. Weet je het zeker ?"
+                    confirm_text: "Herstellen"
+                    dismiss_text: "Annuleren"
                 color: "#01a180"
                 text: Standaardinstellingen
           - type: markdown

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1419,8 +1419,13 @@ views:
                 name: Error
               - entity: sensor.zendure_offgrid_mode
                 name: Offgrid Mode
-              - entity: sensor.zendure_pv_export_mode
-                name: PV Export Mode
+              - type: conditional
+                conditions:
+                  - entity: input_boolean.dashboard_setting_show_pv
+                    state: 'on'
+                row:
+                  entity: sensor.zendure_pv_export_mode
+                  name: PV Export Mode
               - entity: sensor.zendure_calibrating
                 name: Calibrating
               - entity: sensor.zendure_inverter_max_charge_power

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -2664,6 +2664,11 @@ views:
                   target:
                     entity_id: input_button.zendure_setting_set_default_settings
                   data: {}
+                  confirmation:
+                    title: "Restore default settings ?"
+                    text: "Your current settings will be lost and replaced by the default settings. Are you sure?"
+                    confirm_text: "Restore"
+                    dismiss_text: "Cancel"
                 text: Default settings
                 color: "#01a180"
           - type: markdown


### PR DESCRIPTION
Hi everyone,

This PR conditionally displays the **PV Export Mode** entity in the Health dashboard based on the **Show PV on Dashboard** setting.

When **Show PV on Dashboard** is disabled, the **PV Export Mode** entity is hidden. When it is enabled, the entity is displayed as before.

### Changes

- Added conditional visibility to the **PV Export Mode** entity in the Health dashboard
- Visibility is controlled by the **Show PV on Dashboard** setting
- Applied the same change to both the Global (EN) and NL versions, using their respective entity IDs
- No changes to the entity itself or its functionality

Best regards,