### PR TITLE
Conditionally show PV Export Mode on the health dashboard

### DIFF
--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -1424,8 +1424,13 @@ views:
                 name: Error
               - entity: sensor.zendure_2400_ac_offgrid_modus
                 name: Offgrid Modus
-              - entity: sensor.zendure_2400_ac_pv_export_modus
-                name: PV Export Modus
+              - type: conditional
+                conditions:
+                  - entity: input_boolean.pv_tonen_op_dashboard
+                    state: 'on'
+                row:
+                  entity: sensor.zendure_2400_ac_pv_export_modus
+                  name: PV Export Modus
               - entity: sensor.zendure_2400_ac_kalibreren
                 name: Kalibreren
               - entity: sensor.zendure_2400_ac_omvormer_max_oplaadvermogen

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -1419,8 +1419,13 @@ views:
                 name: Error
               - entity: sensor.zendure_offgrid_mode
                 name: Offgrid Mode
-              - entity: sensor.zendure_pv_export_mode
-                name: PV Export Mode
+              - type: conditional
+                conditions:
+                  - entity: input_boolean.dashboard_setting_show_pv
+                    state: 'on'
+                row:
+                  entity: sensor.zendure_pv_export_mode
+                  name: PV Export Mode
               - entity: sensor.zendure_calibrating
                 name: Calibrating
               - entity: sensor.zendure_inverter_max_charge_power


### PR DESCRIPTION
Hi everyone,

This PR conditionally displays the **PV Export Mode** entity in the Health dashboard based on the **Show PV on Dashboard** setting.

When **Show PV on Dashboard** is disabled, the **PV Export Mode** entity is hidden.
<img width="496" height="105" alt="image" src="https://github.com/user-attachments/assets/7a2043c5-0d40-4c8f-b6d4-5fcbab63eb57" />

When it is enabled, the entity is displayed as before.
<img width="500" height="154" alt="image" src="https://github.com/user-attachments/assets/d9a31cf7-d190-4eb6-b7de-3c0a13680c8d" />

### Changes
- Added conditional visibility to sensor.zendure_pv_export_mode
- Visibility is controlled by input_boolean.dashboard_setting_show_pv
- No changes to the entity itself or its functionality

Best regards