### PR TITLE
Add confirmation dialog for restoring default settings

### DIFF
--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -2664,6 +2664,11 @@ views:
                   target:
                     entity_id: input_button.zendure_2400_ac_advies_instellingen_overnemen
                   data: {}
+                  confirmation:
+                    title: "Standaardinstellingen herstellen ?"
+                    text: "Je huidige instellingen gaan verloren en worden vervangen door de standaardinstellingen. Weet je het zeker ?"
+                    confirm_text: "Herstellen"
+                    dismiss_text: "Annuleren"
                 color: "#01a180"
                 text: Standaardinstellingen
           - type: markdown

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -2659,6 +2659,11 @@ views:
                   target:
                     entity_id: input_button.zendure_setting_set_default_settings
                   data: {}
+                  confirmation:
+                    title: "Restore default settings ?"
+                    text: "Your current settings will be lost and replaced by the default settings. Are you sure?"
+                    confirm_text: "Restore"
+                    dismiss_text: "Cancel"
                 text: Default settings
                 color: "#01a180"
           - type: markdown


### PR DESCRIPTION
Hi everyone,

This PR adds a confirmation dialog to the **Default settings** button to prevent accidental resets of the current configuration.
<img width="297" height="92" alt="image" src="https://github.com/user-attachments/assets/266e40b8-d8be-4e83-b035-bd1bb4a97345" />


The confirmation has been added to both the **Global (EN)** and **NL** dashboards, with localized text and button labels.

### Changes

- Added a confirmation dialog before restoring default settings
- Added localized confirmation text for **English** and **Dutch**
- No changes to the default settings themselves

### Result

When clicking **Default settings**, a confirmation dialog is displayed before any settings are restored.
<img width="781" height="320" alt="image" src="https://github.com/user-attachments/assets/76cf19cb-b024-49a3-a984-a1e25797751a" />

Best regards