### PR TITLE
Allow negative discharge buffer values

### DIFF
--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -167,7 +167,7 @@ input_number:
   zendure_2400_ac_ontlaadmarge:
     name: Zendure 2400 AC Ontlaadmarge
     icon: mdi:arrow-expand-vertical
-    min: 0
+    min: -100
     max: 250
     step: 1
     mode: box

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -167,7 +167,7 @@ input_number:
   zendure_setting_discharge_buffer:
     name: Zendure Discharge Buffer
     icon: mdi:arrow-expand-vertical
-    min: 0
+    min: -100
     max: 250
     step: 1
     mode: box


### PR DESCRIPTION
## Summary

This PR allows negative values for the **Discharge Buffer** setting.

A negative discharge buffer can intentionally maintain a small grid import margin, helping to reduce accidental energy export caused by rapid load fluctuations or inverter response delays.

## Changes

- Lowered the minimum Discharge Buffer value from `0 W` to `-100 W`
- Applied the change to both the Global (EN) and Dutch (NL) integrations

Closes #251