### PR TITLE
Optimise number of cheap timeslots for dynamic trading

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1506,17 +1506,18 @@ actions:
             then:
               - alias: >-
                   Vergroot de goedkoopste periodes van 11 tot 23 en houd het laatste aantal
-                  waarvan de spread binnen 2% van de laagste prijs van de dag blijft
+                  waarvan de gemiddelde prijs binnen 2% van het gemiddelde over de 11
+                  goedkoopste periodes blijft
                 variables:
                   optimal_periods: >-
                     {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
                     {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
-                    {% set laagste = waarden | first %}
-                    {% set drempel = 0.02 * (laagste | abs) %}
+                    {% set basis = (waarden[:11] | sum) / 11 %}
+                    {% set drempel = 0.02 * (basis | abs) %}
                     {% set maxn = [23, waarden | count] | min %}
                     {% set ns = namespace(gekozen=maxn, gevonden=false) %}
-                    {% for x in range(11, maxn + 1) %}
-                    {% if not ns.gevonden and (waarden[x - 1] - laagste) > drempel %}
+                    {% for x in range(12, maxn + 1) %}
+                    {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
                     {% set ns.gekozen = x - 1 %}
                     {% set ns.gevonden = true %}
                     {% endif %}

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -44,6 +44,11 @@ triggers:
     id: modus_dynamisch_spread
   - trigger: state
     entity_id:
+      - input_boolean.dynamisch_oplaadvermogen_optimalisatie
+      - input_text.dynamisch_handmatige_periode
+    id: dynamisch_oplaadvermogen_optimalisatie
+  - trigger: state
+    entity_id:
       - input_number.zendure_2400_ac_max_oplaadvermogen
     id: systeem_instelling_maxoplaadvermogen
   - trigger: state
@@ -1442,6 +1447,7 @@ actions:
           - condition: trigger
             id:
               - dynamisch_middernacht
+              - dynamisch_oplaadvermogen_optimalisatie
           - condition: template
             value_template: >-
               {{
@@ -1449,45 +1455,45 @@ actions:
               }}
             alias: input_text.dynamisch_nordpool_sensor is gevuld
         sequence:
-          - alias: Zet goedkoopste periode van morgen naar vandaag
-            target:
-              entity_id: input_number.dynamisch_goedkoopste_x_periode
-            data:
-              value: >-
-                {{ states('input_number.dynamisch_goedkoopste_x_periode_morgen')
-                | float }}
-            action: input_number.set_value
-          - alias: Zet duurste periode van morgen naar vandaag
-            target:
-              entity_id: input_number.dynamisch_duurste_x_periode
-            data:
-              value: >-
-                {{ states('input_number.dynamisch_duurste_x_periode_morgen') |
-                float }}
-            action: input_number.set_value
-          - alias: Zet handmatige periode van morgen naar vandaag
-            target:
-              entity_id: input_text.dynamisch_handmatige_periode
-            data:
-              value: "{{ states('input_text.dynamisch_handmatige_periode_morgen') }}"
-            action: input_text.set_value
-          - alias: Reset handmatige periode van morgen
-            target:
-              entity_id: input_text.dynamisch_handmatige_periode_morgen
-            data:
-              value: ""
-            action: input_text.set_value
-          - action: logbook.log
-            data:
-              message: ⚙️Dynamische instelling overzetten van morgen naar vandaag —
-              entity_id: input_select.zendure_2400_ac_modus_selecteren
-              name: " "
-          - alias: Wachten tot de dynamische prijzen van vandaag beschikbaar zijn
-            wait_template: >-
-              {% set p = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
-              {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
-            timeout: "00:10:00"
-            continue_on_timeout: true
+          - alias: Dynamische instellingen van morgen naar vandaag, alleen om middernacht
+            if:
+              - condition: trigger
+                id:
+                  - dynamisch_middernacht
+            then:
+              - alias: Zet goedkoopste periode van morgen naar vandaag
+                target:
+                  entity_id: input_number.dynamisch_goedkoopste_x_periode
+                data:
+                  value: >-
+                    {{ states('input_number.dynamisch_goedkoopste_x_periode_morgen')
+                    | float }}
+                action: input_number.set_value
+              - alias: Zet duurste periode van morgen naar vandaag
+                target:
+                  entity_id: input_number.dynamisch_duurste_x_periode
+                data:
+                  value: >-
+                    {{ states('input_number.dynamisch_duurste_x_periode_morgen') |
+                    float }}
+                action: input_number.set_value
+              - alias: Zet handmatige periode van morgen naar vandaag
+                target:
+                  entity_id: input_text.dynamisch_handmatige_periode
+                data:
+                  value: "{{ states('input_text.dynamisch_handmatige_periode_morgen') }}"
+                action: input_text.set_value
+              - alias: Reset handmatige periode van morgen
+                target:
+                  entity_id: input_text.dynamisch_handmatige_periode_morgen
+                data:
+                  value: ""
+                action: input_text.set_value
+              - action: logbook.log
+                data:
+                  message: ⚙️Dynamische instelling overzetten van morgen naar vandaag —
+                  entity_id: input_select.zendure_2400_ac_modus_selecteren
+                  name: " "
           - alias: Optimaliseer het aantal goedkoopste periodes en het dynamische oplaadvermogen
             if:
               - alias: Optimalisatie van het oplaadvermogen is ingeschakeld
@@ -1498,56 +1504,83 @@ actions:
                 condition: template
                 value_template: >-
                   {{ states('input_text.dynamisch_handmatige_periode') | length == 0 }}
-              - alias: De prijzen van vandaag zijn beschikbaar
-                condition: template
-                value_template: >-
+            then:
+              - alias: Wachten tot de dynamische prijzen van vandaag beschikbaar zijn
+                wait_template: >-
                   {% set p = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
                   {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
-            then:
+                timeout: "00:10:00"
+                continue_on_timeout: true
+              - alias: Pas de optimalisatie toe zodra de prijzen van vandaag beschikbaar zijn
+                if:
+                  - alias: De prijzen van vandaag zijn beschikbaar
+                    condition: template
+                    value_template: >-
+                      {% set p = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+                      {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+                else:
+                  - alias: >-
+                      Geen prijzen voor vandaag, wis het oplaadvermogen zodat Dynamisch Handelen
+                      terugvalt op het maximale oplaadvermogen
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamisch_oplaadvermogen
+                    data:
+                      value: 0
+                then:
+                  - alias: >-
+                      Vergroot de goedkoopste periodes van 11 tot 23 en houd het laatste aantal
+                      waarvan de gemiddelde prijs binnen 2% van het gemiddelde over de 11
+                      goedkoopste periodes blijft
+                    variables:
+                      optimal_periods: >-
+                        {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+                        {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
+                        {% set basis = (waarden[:11] | sum) / 11 %}
+                        {% set drempel = 0.02 * (basis | abs) %}
+                        {% set maxn = [23, waarden | count] | min %}
+                        {% set ns = namespace(gekozen=maxn, gevonden=false) %}
+                        {% for x in range(12, maxn + 1) %}
+                        {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
+                        {% set ns.gekozen = x - 1 %}
+                        {% set ns.gevonden = true %}
+                        {% endif %}
+                        {% endfor %}
+                        {{ ns.gekozen }}
+                  - alias: Oplaadvermogen via y = 6.3131x² - 341.16x + 6002.5, begrensd op het max. oplaadvermogen
+                    variables:
+                      optimal_power: >-
+                        {% set x = optimal_periods | int %}
+                        {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
+                        states('input_number.zendure_2400_ac_max_oplaadvermogen') | int(12000) ] | min }}
+                  - alias: Zet het geoptimaliseerde aantal goedkoopste periodes voor vandaag
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamisch_goedkoopste_x_periode
+                    data:
+                      value: "{{ optimal_periods | int }}"
+                  - alias: Zet het dynamische oplaadvermogen voor vandaag
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamisch_oplaadvermogen
+                    data:
+                      value: "{{ optimal_power | int }}"
+                  - action: logbook.log
+                    data:
+                      message: >-
+                        ⚙️Dynamisch oplaadvermogen geoptimaliseerd naar {{ optimal_power | int }} watt
+                        over de {{ optimal_periods | int }} goedkoopste periodes —
+                      entity_id: input_select.zendure_2400_ac_modus_selecteren
+                      name: " "
+            else:
               - alias: >-
-                  Vergroot de goedkoopste periodes van 11 tot 23 en houd het laatste aantal
-                  waarvan de gemiddelde prijs binnen 2% van het gemiddelde over de 11
-                  goedkoopste periodes blijft
-                variables:
-                  optimal_periods: >-
-                    {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
-                    {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
-                    {% set basis = (waarden[:11] | sum) / 11 %}
-                    {% set drempel = 0.02 * (basis | abs) %}
-                    {% set maxn = [23, waarden | count] | min %}
-                    {% set ns = namespace(gekozen=maxn, gevonden=false) %}
-                    {% for x in range(12, maxn + 1) %}
-                    {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
-                    {% set ns.gekozen = x - 1 %}
-                    {% set ns.gevonden = true %}
-                    {% endif %}
-                    {% endfor %}
-                    {{ ns.gekozen }}
-              - alias: Oplaadvermogen via y = 6.3131x² - 341.16x + 6002.5, begrensd op het max. oplaadvermogen
-                variables:
-                  optimal_power: >-
-                    {% set x = optimal_periods | int %}
-                    {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
-                    states('input_number.zendure_2400_ac_max_oplaadvermogen') | int(12000) ] | min }}
-              - alias: Zet het geoptimaliseerde aantal goedkoopste periodes voor vandaag
-                action: input_number.set_value
-                target:
-                  entity_id: input_number.dynamisch_goedkoopste_x_periode
-                data:
-                  value: "{{ optimal_periods | int }}"
-              - alias: Zet het dynamische oplaadvermogen voor vandaag
+                  Optimalisatie uit of handmatige periodes in gebruik, wis het oplaadvermogen
+                  zodat Dynamisch Handelen terugvalt op het maximale oplaadvermogen
                 action: input_number.set_value
                 target:
                   entity_id: input_number.dynamisch_oplaadvermogen
                 data:
-                  value: "{{ optimal_power | int }}"
-              - action: logbook.log
-                data:
-                  message: >-
-                    ⚙️Dynamisch oplaadvermogen geoptimaliseerd naar {{ optimal_power | int }} watt
-                    over de {{ optimal_periods | int }} goedkoopste periodes —
-                  entity_id: input_select.zendure_2400_ac_modus_selecteren
-                  name: " "
+                  value: 0
         alias: Dynamisch omzetten van morgen naar vandaag
       - conditions:
           - condition: trigger

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1482,6 +1482,71 @@ actions:
               message: ⚙️Dynamische instelling overzetten van morgen naar vandaag —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
+          - alias: Wachten tot de dynamische prijzen van vandaag beschikbaar zijn
+            wait_template: >-
+              {% set p = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+              {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+            timeout: "00:10:00"
+            continue_on_timeout: true
+          - alias: Optimaliseer het aantal goedkoopste periodes en het dynamische oplaadvermogen
+            if:
+              - alias: Optimalisatie van het oplaadvermogen is ingeschakeld
+                condition: state
+                entity_id: input_boolean.dynamisch_oplaadvermogen_optimalisatie
+                state: "on"
+              - alias: Geen handmatige periodes ingesteld voor vandaag
+                condition: template
+                value_template: >-
+                  {{ states('input_text.dynamisch_handmatige_periode') | length == 0 }}
+              - alias: De prijzen van vandaag zijn beschikbaar
+                condition: template
+                value_template: >-
+                  {% set p = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+                  {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+            then:
+              - alias: >-
+                  Vergroot de goedkoopste periodes van 11 tot 23 en houd het laatste aantal
+                  waarvan de spread binnen 2% van de laagste prijs van de dag blijft
+                variables:
+                  optimal_periods: >-
+                    {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') or [] %}
+                    {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
+                    {% set laagste = waarden | first %}
+                    {% set drempel = 0.02 * (laagste | abs) %}
+                    {% set maxn = [23, waarden | count] | min %}
+                    {% set ns = namespace(gekozen=maxn, gevonden=false) %}
+                    {% for x in range(11, maxn + 1) %}
+                    {% if not ns.gevonden and (waarden[x - 1] - laagste) > drempel %}
+                    {% set ns.gekozen = x - 1 %}
+                    {% set ns.gevonden = true %}
+                    {% endif %}
+                    {% endfor %}
+                    {{ ns.gekozen }}
+              - alias: Oplaadvermogen via y = 6.3131x² - 341.16x + 6002.5, begrensd op het max. oplaadvermogen
+                variables:
+                  optimal_power: >-
+                    {% set x = optimal_periods | int %}
+                    {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
+                    states('input_number.zendure_2400_ac_max_oplaadvermogen') | int(12000) ] | min }}
+              - alias: Zet het geoptimaliseerde aantal goedkoopste periodes voor vandaag
+                action: input_number.set_value
+                target:
+                  entity_id: input_number.dynamisch_goedkoopste_x_periode
+                data:
+                  value: "{{ optimal_periods | int }}"
+              - alias: Zet het dynamische oplaadvermogen voor vandaag
+                action: input_number.set_value
+                target:
+                  entity_id: input_number.dynamisch_oplaadvermogen
+                data:
+                  value: "{{ optimal_power | int }}"
+              - action: logbook.log
+                data:
+                  message: >-
+                    ⚙️Dynamisch oplaadvermogen geoptimaliseerd naar {{ optimal_power | int }} watt
+                    over de {{ optimal_periods | int }} goedkoopste periodes —
+                  entity_id: input_select.zendure_2400_ac_modus_selecteren
+                  name: " "
         alias: Dynamisch omzetten van morgen naar vandaag
       - conditions:
           - condition: trigger
@@ -1751,15 +1816,26 @@ actions:
               minutes: 0
               seconds: 5
               milliseconds: 0
-          - action: rest_command.zendure_snel_laden
+          - alias: >-
+              Laad tijdens Dynamisch Handelen met het geoptimaliseerde oplaadvermogen, anders
+              met het maximale oplaadvermogen
+            action: rest_command.zendure_snel_laden
             data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                {% set optimised = is_state('input_select.zendure_2400_ac_modus_selecteren', 'Dynamisch Handelen')
+                and is_state('input_boolean.dynamisch_oplaadvermogen_optimalisatie', 'on')
+                and states('input_number.dynamisch_oplaadvermogen') | float(0) > 0 %}
+                {{ states('input_number.dynamisch_oplaadvermogen') | int if optimised
+                else states('input_number.zendure_2400_ac_max_oplaadvermogen') | int }}
           - action: logbook.log
             data:
-              message: 💲Dynamisch goedkoop laden gestart —
+              message: >-
+                {% set optimised = is_state('input_select.zendure_2400_ac_modus_selecteren', 'Dynamisch Handelen')
+                and is_state('input_boolean.dynamisch_oplaadvermogen_optimalisatie', 'on')
+                and states('input_number.dynamisch_oplaadvermogen') | float(0) > 0 %}
+                💲Dynamisch goedkoop laden gestart op {{ states('input_number.dynamisch_oplaadvermogen') | int
+                if optimised else states('input_number.zendure_2400_ac_max_oplaadvermogen') | int }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
           - wait_for_trigger:

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -74,6 +74,18 @@ views:
               - condition: state
                 entity: input_select.zendure_2400_ac_modus_selecteren
                 state: Handmatig
+          - type: entities
+            entities:
+              - entity: input_number.dynamisch_oplaadvermogen
+                name: Oplaadvermogen
+                secondary_info: last-changed
+            visibility:
+              - condition: state
+                entity: input_select.zendure_2400_ac_modus_selecteren
+                state: Dynamisch Handelen
+              - condition: state
+                entity: input_boolean.dynamisch_oplaadvermogen_optimalisatie
+                state: "on"
           - type: custom:apexcharts-card
             experimental:
               hidden_by_default: true
@@ -1224,6 +1236,8 @@ views:
                 name: Duurste Periodes
               - entity: input_text.dynamisch_handmatige_periode
                 name: Handmatige Periodes
+              - entity: input_number.dynamisch_oplaadvermogen
+                name: Dynamisch Oplaadvermogen
           - type: heading
             icon: ""
             heading: Dynamisch Morgen
@@ -2893,6 +2907,17 @@ views:
 
               Heb je een 15 minuten contract vink dit dan aan zodat de grafieken
               en de prijzen goed gezet worden.
+
+
+              Staat **Oplaadvermogen Optimalisatie⚙️** aan, dan wordt elke nacht
+              het aantal goedkoopste periodes uitgebreid van 11 tot 23, zolang
+              de spread binnen die periodes binnen 2% van de laagste prijs van
+              de dag blijft. Het gevonden aantal komt in **Goedkoopste
+              Periodes** te staan en het bijbehorende vermogen in **Dynamisch
+              Oplaadvermogen**, waarmee Dynamisch Handelen laadt in plaats van
+              met het maximale oplaadvermogen. Ontladen blijft op het maximale
+              ontlaadvermogen. Handmatige periodes gaan voor: zijn die
+              ingevuld, dan wordt de optimalisatie overgeslagen.
             text_only: true
             visibility:
               - condition: state
@@ -2910,6 +2935,8 @@ views:
                 name: Minimale Spread
               - entity: input_boolean.dynamisch_15_minuten
                 name: 15 Minuten Tarieven Actief
+              - entity: input_boolean.dynamisch_oplaadvermogen_optimalisatie
+                name: Oplaadvermogen Optimalisatie
             visibility:
               - condition: state
                 entity: input_boolean.dynamisch_tonen_op_dashboard

--- a/Dutch (NL) Integration/dashboard_nl.yaml
+++ b/Dutch (NL) Integration/dashboard_nl.yaml
@@ -2911,8 +2911,8 @@ views:
 
               Staat **Oplaadvermogen Optimalisatie⚙️** aan, dan wordt elke nacht
               het aantal goedkoopste periodes uitgebreid van 11 tot 23, zolang
-              de spread binnen die periodes binnen 2% van de laagste prijs van
-              de dag blijft. Het gevonden aantal komt in **Goedkoopste
+              de gemiddelde prijs over die periodes binnen 2% van het gemiddelde
+              over de 11 goedkoopste periodes blijft. Het gevonden aantal komt in **Goedkoopste
               Periodes** te staan en het bijbehorende vermogen in **Dynamisch
               Oplaadvermogen**, waarmee Dynamisch Handelen laadt in plaats van
               met het maximale oplaadvermogen. Ontladen blijft op het maximale

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -25,6 +25,10 @@ input_boolean:
     name: Dynamisch 15 Minuten
     icon: mdi:clock-time-three-outline
 
+  dynamisch_oplaadvermogen_optimalisatie:
+    name: Dynamisch Oplaadvermogen Optimalisatie
+    icon: mdi:auto-fix
+
   dynamisch_recent_geladen:
     name: Dynamisch Recent Geladen
     icon: mdi:battery-check
@@ -222,6 +226,15 @@ input_number:
     max: 96
     step: 1
     mode: box
+
+  dynamisch_oplaadvermogen:
+    name: Dynamisch Oplaadvermogen
+    icon: mdi:battery-charging-medium
+    min: 0
+    max: 12000
+    step: 1
+    mode: box
+    unit_of_measurement: "W"
 
   zendure_2400_ac_minimaal_toegestaan_laadpercentage:
     name: Zendure 2400 AC Minimaal Toegestaan Laadpercentage

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1483,17 +1483,17 @@ actions:
             then:
               - alias: >-
                   Widen the cheapest periods from 11 up to 23 and keep the last count whose
-                  spread stays within 2% of the lowest price of the day
+                  average price stays within 2% of the average over the 11 cheapest periods
                 variables:
                   optimal_periods: >-
                     {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
                     {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
-                    {% set laagste = waarden | first %}
-                    {% set drempel = 0.02 * (laagste | abs) %}
+                    {% set basis = (waarden[:11] | sum) / 11 %}
+                    {% set drempel = 0.02 * (basis | abs) %}
                     {% set maxn = [23, waarden | count] | min %}
                     {% set ns = namespace(gekozen=maxn, gevonden=false) %}
-                    {% for x in range(11, maxn + 1) %}
-                    {% if not ns.gevonden and (waarden[x - 1] - laagste) > drempel %}
+                    {% for x in range(12, maxn + 1) %}
+                    {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
                     {% set ns.gekozen = x - 1 %}
                     {% set ns.gevonden = true %}
                     {% endif %}

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1459,6 +1459,71 @@ actions:
               message: ⚙️Dynamic period settings copied from tomorrow to today —
               entity_id: input_select.zendure_operation_mode
               name: " "
+          - alias: Wait until today's dynamic prices are available
+            wait_template: >-
+              {% set p = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+              {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+            timeout: "00:10:00"
+            continue_on_timeout: true
+          - alias: Optimise the number of cheapest periods and the dynamic charge power
+            if:
+              - alias: Charge power optimisation is enabled
+                condition: state
+                entity_id: input_boolean.dynamic_setting_charge_power_optimisation
+                state: "on"
+              - alias: No manual periods defined for today
+                condition: template
+                value_template: >-
+                  {{ states('input_text.dynamic_manual_period') | length == 0 }}
+              - alias: Today's prices are available
+                condition: template
+                value_template: >-
+                  {% set p = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+                  {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+            then:
+              - alias: >-
+                  Widen the cheapest periods from 11 up to 23 and keep the last count whose
+                  spread stays within 2% of the lowest price of the day
+                variables:
+                  optimal_periods: >-
+                    {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+                    {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
+                    {% set laagste = waarden | first %}
+                    {% set drempel = 0.02 * (laagste | abs) %}
+                    {% set maxn = [23, waarden | count] | min %}
+                    {% set ns = namespace(gekozen=maxn, gevonden=false) %}
+                    {% for x in range(11, maxn + 1) %}
+                    {% if not ns.gevonden and (waarden[x - 1] - laagste) > drempel %}
+                    {% set ns.gekozen = x - 1 %}
+                    {% set ns.gevonden = true %}
+                    {% endif %}
+                    {% endfor %}
+                    {{ ns.gekozen }}
+              - alias: Charge power from y = 6.3131x² - 341.16x + 6002.5, capped at the maximum charge power
+                variables:
+                  optimal_power: >-
+                    {% set x = optimal_periods | int %}
+                    {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
+                    states('input_number.zendure_setting_max_charge_power') | int(12000) ] | min }}
+              - alias: Set the optimised number of cheapest periods for today
+                action: input_number.set_value
+                target:
+                  entity_id: input_number.dynamic_lowest_price_x_period
+                data:
+                  value: "{{ optimal_periods | int }}"
+              - alias: Set the dynamic charge power for today
+                action: input_number.set_value
+                target:
+                  entity_id: input_number.dynamic_charge_power
+                data:
+                  value: "{{ optimal_power | int }}"
+              - action: logbook.log
+                data:
+                  message: >-
+                    ⚙️Dynamic charge power optimised to {{ optimal_power | int }} watt over the
+                    {{ optimal_periods | int }} cheapest periods —
+                  entity_id: input_select.zendure_operation_mode
+                  name: " "
         alias: Set dynamic manual periods from tomorrow into today
       - conditions:
           - condition: trigger
@@ -1725,15 +1790,26 @@ actions:
               minutes: 0
               seconds: 5
               milliseconds: 0
-          - action: rest_command.zendure_quick_charge
+          - alias: >-
+              Charge at the optimised dynamic charge power during Dynamic Trading, otherwise at
+              the maximum charge power
+            action: rest_command.zendure_quick_charge
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
-                }}
+                {% set optimised = is_state('input_select.zendure_operation_mode', 'Dynamic Trading')
+                and is_state('input_boolean.dynamic_setting_charge_power_optimisation', 'on')
+                and states('input_number.dynamic_charge_power') | float(0) > 0 %}
+                {{ states('input_number.dynamic_charge_power') | int if optimised
+                else states('input_number.zendure_setting_max_charge_power') | int }}
           - action: logbook.log
             data:
-              message: 💲Dynamic cheap charging started —
+              message: >-
+                {% set optimised = is_state('input_select.zendure_operation_mode', 'Dynamic Trading')
+                and is_state('input_boolean.dynamic_setting_charge_power_optimisation', 'on')
+                and states('input_number.dynamic_charge_power') | float(0) > 0 %}
+                💲Dynamic cheap charging started at {{ states('input_number.dynamic_charge_power') | int
+                if optimised else states('input_number.zendure_setting_max_charge_power') | int }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
           - wait_for_trigger:

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -44,6 +44,11 @@ triggers:
     id: modus_dynamisch_spread
   - trigger: state
     entity_id:
+      - input_boolean.dynamic_setting_charge_power_optimisation
+      - input_text.dynamic_manual_period
+    id: dynamic_charge_power_optimisation
+  - trigger: state
+    entity_id:
       - input_number.zendure_setting_max_charge_power
     id: systeem_instelling_maxoplaadvermogen
   - trigger: state
@@ -1418,6 +1423,7 @@ actions:
           - condition: trigger
             id:
               - dynamisch_middernacht
+              - dynamic_charge_power_optimisation
           - condition: template
             value_template: >-
               {{
@@ -1425,46 +1431,46 @@ actions:
               }}
             alias: input_text.dynamic_setting_nordpool_sensor is gevuld
         sequence:
-          - alias: Zet goedkoopste periode van morgen naar vandaag
-            target:
-              entity_id: input_number.dynamic_lowest_price_x_period
-            data:
-              value: >-
-                {{ states('input_number.dynamic_lowest_price_x_period_tomorrow')
-                | float }}
-            action: input_number.set_value
-          - alias: Zet duurste periode van morgen naar vandaag
-            target:
-              entity_id: input_number.dynamic_highest_price_x_period
-            data:
-              value: >-
-                {{
-                states('input_number.dynamic_highest_price_x_period_tomorrow') |
-                float }}
-            action: input_number.set_value
-          - alias: Zet handmatige periode van morgen naar vandaag
-            target:
-              entity_id: input_text.dynamic_manual_period
-            data:
-              value: "{{ states('input_text.dynamic_manual_period_tomorrow') }}"
-            action: input_text.set_value
-          - alias: Reset handmatige periode van morgen
-            target:
-              entity_id: input_text.dynamic_manual_period_tomorrow
-            data:
-              value: ""
-            action: input_text.set_value
-          - action: logbook.log
-            data:
-              message: ⚙️Dynamic period settings copied from tomorrow to today —
-              entity_id: input_select.zendure_operation_mode
-              name: " "
-          - alias: Wait until today's dynamic prices are available
-            wait_template: >-
-              {% set p = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
-              {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
-            timeout: "00:10:00"
-            continue_on_timeout: true
+          - alias: Copy tomorrow's dynamic settings into today, at midnight only
+            if:
+              - condition: trigger
+                id:
+                  - dynamisch_middernacht
+            then:
+              - alias: Zet goedkoopste periode van morgen naar vandaag
+                target:
+                  entity_id: input_number.dynamic_lowest_price_x_period
+                data:
+                  value: >-
+                    {{ states('input_number.dynamic_lowest_price_x_period_tomorrow')
+                    | float }}
+                action: input_number.set_value
+              - alias: Zet duurste periode van morgen naar vandaag
+                target:
+                  entity_id: input_number.dynamic_highest_price_x_period
+                data:
+                  value: >-
+                    {{
+                    states('input_number.dynamic_highest_price_x_period_tomorrow') |
+                    float }}
+                action: input_number.set_value
+              - alias: Zet handmatige periode van morgen naar vandaag
+                target:
+                  entity_id: input_text.dynamic_manual_period
+                data:
+                  value: "{{ states('input_text.dynamic_manual_period_tomorrow') }}"
+                action: input_text.set_value
+              - alias: Reset handmatige periode van morgen
+                target:
+                  entity_id: input_text.dynamic_manual_period_tomorrow
+                data:
+                  value: ""
+                action: input_text.set_value
+              - action: logbook.log
+                data:
+                  message: ⚙️Dynamic period settings copied from tomorrow to today —
+                  entity_id: input_select.zendure_operation_mode
+                  name: " "
           - alias: Optimise the number of cheapest periods and the dynamic charge power
             if:
               - alias: Charge power optimisation is enabled
@@ -1475,55 +1481,82 @@ actions:
                 condition: template
                 value_template: >-
                   {{ states('input_text.dynamic_manual_period') | length == 0 }}
-              - alias: Today's prices are available
-                condition: template
-                value_template: >-
+            then:
+              - alias: Wait until today's dynamic prices are available
+                wait_template: >-
                   {% set p = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
                   {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
-            then:
+                timeout: "00:10:00"
+                continue_on_timeout: true
+              - alias: Apply the optimisation once today's prices are available
+                if:
+                  - alias: Today's prices are available
+                    condition: template
+                    value_template: >-
+                      {% set p = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+                      {{ p | count >= 11 and (p[0]['start'] | as_datetime | as_local).date() == now().date() }}
+                else:
+                  - alias: >-
+                      No prices for today, clear the charge power so Dynamic Trading falls back
+                      to the maximum charge power
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamic_charge_power
+                    data:
+                      value: 0
+                then:
+                  - alias: >-
+                      Widen the cheapest periods from 11 up to 23 and keep the last count whose
+                      average price stays within 2% of the average over the 11 cheapest periods
+                    variables:
+                      optimal_periods: >-
+                        {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
+                        {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
+                        {% set basis = (waarden[:11] | sum) / 11 %}
+                        {% set drempel = 0.02 * (basis | abs) %}
+                        {% set maxn = [23, waarden | count] | min %}
+                        {% set ns = namespace(gekozen=maxn, gevonden=false) %}
+                        {% for x in range(12, maxn + 1) %}
+                        {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
+                        {% set ns.gekozen = x - 1 %}
+                        {% set ns.gevonden = true %}
+                        {% endif %}
+                        {% endfor %}
+                        {{ ns.gekozen }}
+                  - alias: Charge power from y = 6.3131x² - 341.16x + 6002.5, capped at the maximum charge power
+                    variables:
+                      optimal_power: >-
+                        {% set x = optimal_periods | int %}
+                        {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
+                        states('input_number.zendure_setting_max_charge_power') | int(12000) ] | min }}
+                  - alias: Set the optimised number of cheapest periods for today
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamic_lowest_price_x_period
+                    data:
+                      value: "{{ optimal_periods | int }}"
+                  - alias: Set the dynamic charge power for today
+                    action: input_number.set_value
+                    target:
+                      entity_id: input_number.dynamic_charge_power
+                    data:
+                      value: "{{ optimal_power | int }}"
+                  - action: logbook.log
+                    data:
+                      message: >-
+                        ⚙️Dynamic charge power optimised to {{ optimal_power | int }} watt over the
+                        {{ optimal_periods | int }} cheapest periods —
+                      entity_id: input_select.zendure_operation_mode
+                      name: " "
+            else:
               - alias: >-
-                  Widen the cheapest periods from 11 up to 23 and keep the last count whose
-                  average price stays within 2% of the average over the 11 cheapest periods
-                variables:
-                  optimal_periods: >-
-                    {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') or [] %}
-                    {% set waarden = prijzen | map(attribute='value') | map('float') | sort | list %}
-                    {% set basis = (waarden[:11] | sum) / 11 %}
-                    {% set drempel = 0.02 * (basis | abs) %}
-                    {% set maxn = [23, waarden | count] | min %}
-                    {% set ns = namespace(gekozen=maxn, gevonden=false) %}
-                    {% for x in range(12, maxn + 1) %}
-                    {% if not ns.gevonden and ((waarden[:x] | sum) / x - basis) > drempel %}
-                    {% set ns.gekozen = x - 1 %}
-                    {% set ns.gevonden = true %}
-                    {% endif %}
-                    {% endfor %}
-                    {{ ns.gekozen }}
-              - alias: Charge power from y = 6.3131x² - 341.16x + 6002.5, capped at the maximum charge power
-                variables:
-                  optimal_power: >-
-                    {% set x = optimal_periods | int %}
-                    {{ [ (6.3131 * x * x - 341.16 * x + 6002.5) | round(0) | int,
-                    states('input_number.zendure_setting_max_charge_power') | int(12000) ] | min }}
-              - alias: Set the optimised number of cheapest periods for today
-                action: input_number.set_value
-                target:
-                  entity_id: input_number.dynamic_lowest_price_x_period
-                data:
-                  value: "{{ optimal_periods | int }}"
-              - alias: Set the dynamic charge power for today
+                  Optimisation disabled or manual periods in use, clear the charge power so
+                  Dynamic Trading falls back to the maximum charge power
                 action: input_number.set_value
                 target:
                   entity_id: input_number.dynamic_charge_power
                 data:
-                  value: "{{ optimal_power | int }}"
-              - action: logbook.log
-                data:
-                  message: >-
-                    ⚙️Dynamic charge power optimised to {{ optimal_power | int }} watt over the
-                    {{ optimal_periods | int }} cheapest periods —
-                  entity_id: input_select.zendure_operation_mode
-                  name: " "
+                  value: 0
         alias: Set dynamic manual periods from tomorrow into today
       - conditions:
           - condition: trigger

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -74,6 +74,18 @@ views:
               - condition: state
                 entity: input_select.zendure_operation_mode
                 state: Manual
+          - type: entities
+            entities:
+              - entity: input_number.dynamic_charge_power
+                name: Charge Power
+                secondary_info: last-changed
+            visibility:
+              - condition: state
+                entity: input_select.zendure_operation_mode
+                state: Dynamic Trading
+              - condition: state
+                entity: input_boolean.dynamic_setting_charge_power_optimisation
+                state: "on"
           - type: custom:apexcharts-card
             experimental:
               hidden_by_default: true
@@ -1220,6 +1232,8 @@ views:
                 name: Highest Price Periods
               - entity: input_text.dynamic_manual_period
                 name: Manual Periods
+              - entity: input_number.dynamic_charge_power
+                name: Dynamic Charge Power
           - type: heading
             icon: ""
             heading: Dynamic Tomorrow
@@ -2884,6 +2898,17 @@ views:
               discharging at low and high tariffs. If you have a 15-minute
               contract, enable this so that the graphs and prices are set
               correctly.
+
+
+              With **Charge Power Optimisation⚙️** enabled, every night the
+              number of cheapest periods is widened from 11 up to 23 for as long
+              as the price spread within those periods stays within 2% of the
+              lowest price of the day. The resulting period count is written to
+              **Lowest Price Periods** and the matching charge power to
+              **Dynamic Charge Power**, which Dynamic Trading then charges at
+              instead of the maximum charge power. Discharging keeps using the
+              maximum discharge power. Manual periods take precedence: when
+              those are filled in, the optimisation is skipped.
             visibility:
               - condition: state
                 entity: input_boolean.dashboard_setting_show_help
@@ -2901,6 +2926,8 @@ views:
                 name: Minimal Spread
               - entity: input_boolean.dynamic_setting_15_minute_interval
                 name: 15 Minute Interval
+              - entity: input_boolean.dynamic_setting_charge_power_optimisation
+                name: Charge Power Optimisation
             visibility:
               - condition: state
                 entity: input_boolean.dashboard_setting_show_dynamic

--- a/Global (EN) Integration/dashboard_global.yaml
+++ b/Global (EN) Integration/dashboard_global.yaml
@@ -2902,8 +2902,8 @@ views:
 
               With **Charge Power Optimisation⚙️** enabled, every night the
               number of cheapest periods is widened from 11 up to 23 for as long
-              as the price spread within those periods stays within 2% of the
-              lowest price of the day. The resulting period count is written to
+              as the average price over those periods stays within 2% of the
+              average over the 11 cheapest periods. The resulting period count is written to
               **Lowest Price Periods** and the matching charge power to
               **Dynamic Charge Power**, which Dynamic Trading then charges at
               instead of the maximum charge power. Discharging keeps using the

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -25,6 +25,10 @@ input_boolean:
     name: Dynamic 15 Minutes Interval
     icon: mdi:clock-time-three-outline
 
+  dynamic_setting_charge_power_optimisation:
+    name: Dynamic Charge Power Optimisation
+    icon: mdi:auto-fix
+
   dynamic_recently_charged:
     name: Dynamic Recently Charged
     icon: mdi:battery-check
@@ -222,6 +226,15 @@ input_number:
     max: 96
     step: 1
     mode: box
+
+  dynamic_charge_power:
+    name: Dynamic Charge Power
+    icon: mdi:battery-charging-medium
+    min: 0
+    max: 12000
+    step: 1
+    mode: box
+    unit_of_measurement: "W"
 
   zendure_setting_minimum_allowed_state_of_charge:
     name: Zendure Minimum Allowed State Of Charge


### PR DESCRIPTION
**Useful only for dynamic trading!**

**Not compatible with my other PR #234 about additional syntax for searching best timeslots.**

_Likely useful only this year, when saldering is in place, in 2027+ a DAO is a better choice._

While expensive timeslots are quite "peaky", with a clear and strong maximum and with prices in nearby slots dropping quickly, the cheap timeslots often are pretty flat in price, and often chargin full speed (for example taking 11 quarters, in my case) vs charging slowly (up to 23 slots, in my case) bring little economical gains, while ensuring lower stress on the batteries and higher efficiencies: with my Solarflow 3000, charging at 1500 W bring about 2% higher RTE than charging at 2500 W, and another % if compared to 3000 W (I didn't test it). Also, batteries stay quite cooler (5 °C for my SF3000).

The idea of this PR is to have the number of cheap slots in dynamic trading adjusted (increased, equivalent to starting from the maximum possible power and decreasing it) while incurring in no more than 2% worse prices (compensated by the increased efficiency).

The algorithm (with parameters hardcoded to my values, it can be changed if desired) starts with 11 quarters, then increases them until the (average!) price increase crosses a 2% threshold, at which point the algorithm reduces the slots by 1. The maximum number of slots allowed is 23, which in my case corresponds to 1500 W charging power.

Then, based on the number of slots, calculates the power needed to fully charge the battery. The parameters are also hardcoded and experimental, based on my battery. The power is stored in a new entity, since it's used only for this purpose.

Discharge power is untoouched to the value set in the preferences.

When the mode in Dynamic trading and dynamic_cheap_hour is YES, charging is started at the preset power (no Flash write needed, only RAM writing).

Remark
If the other feature from #234 is going to be merged (with advantages which are useful also in 2027+), I would need to open a new PR for this feature.