### PR TITLE
Stop discharging when the minimum SOC is reached (Smart Matching)

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1362,6 +1362,80 @@ actions:
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Tijdens opladen balanceren naar -xxx watt (100% van aanbod)
+      - conditions:
+          - condition: trigger
+            id:
+              - aansturing_trigger
+          - condition: or
+            conditions:
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state: Nul op de meter
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state: Alleen slim ontladen
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state:
+                  - Dynamisch NOM
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state:
+                  - Dynamisch NOM (Duur)
+              - condition: state
+                entity_id: input_select.zendure_2400_ac_modus_selecteren
+                state:
+                  - Dynamisch Handelen + NOM
+          - alias: >-
+              Minimaal ingestelde SOC bereikt of ontlaadlimiet gemeld door het
+              apparaat
+            condition: or
+            conditions:
+              - condition: template
+                value_template: |
+                  {{ states('sensor.zendure_2400_ac_laadpercentage') | float(0) <=
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
+              - condition: state
+                entity_id: sensor.zendure_2400_ac_soc_limiet_status
+                state:
+                  - Ontlaadlimiet bereikt
+          - alias: Het apparaat heeft nog een ontlaadvermogen ingesteld staan
+            condition: template
+            value_template: |
+              {{ states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int(0) > 0 }}
+          - alias: Het (beschermings)opladen niet onderbreken
+            condition: numeric_state
+            entity_id: sensor.zendure_2400_ac_vermogen_aansturing
+            below: 30
+          - condition: and
+            conditions:
+              - condition: state
+                entity_id: input_boolean.dynamisch_laden_loopt
+                state:
+                  - "off"
+              - condition: state
+                entity_id: input_boolean.dynamisch_ontladen_loopt
+                state:
+                  - "off"
+          - alias: Benodigde sensoren zijn beschikbaar
+            condition: template
+            value_template: >-
+              {{ states('sensor.zendure_2400_ac_laadpercentage') not in ['unknown',
+              'unavailable']
+                 and states('sensor.zendure_2400_ac_minimale_laadpercentage') not in ['unknown', 'unavailable']
+                 and states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') not in ['unknown', 'unavailable'] }}
+        sequence:
+          - action: rest_command.zendure_stop_met_ontladen
+            data:
+              sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
+          - action: logbook.log
+            data:
+              message: >-
+                🛑Minimale laadpercentage bereikt — ontlaadvermogen teruggezet
+                naar 0 watt —
+              entity_id: input_select.zendure_2400_ac_modus_selecteren
+              name: " "
+        alias: Stop met ontladen wanneer het minimale laadpercentage is bereikt
   - alias: Handmatige Aansturing
     choose:
       - conditions:

--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -1403,7 +1403,20 @@ actions:
             condition: template
             value_template: |
               {{ states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int(0) > 0 }}
-          - alias: Het (beschermings)opladen niet onderbreken
+          - alias: >-
+              Het minimale laadpercentage overlaten aan de SOC bescherming
+              zolang die de batterij (bij)laadt
+            condition: or
+            conditions:
+              - condition: state
+                entity_id: input_boolean.zendure_2400_ac_soc_bescherming_uitgeschakeld
+                state:
+                  - "on"
+              - condition: template
+                value_template: |
+                  {{ states('sensor.zendure_2400_ac_laadpercentage') | float(0) >=
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
+          - alias: Het reeds lopende opladen niet onderbreken
             condition: numeric_state
             entity_id: sensor.zendure_2400_ac_vermogen_aansturing
             below: 30

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1383,7 +1383,20 @@ actions:
             condition: template
             value_template: |
               {{ states('sensor.zendure_set_discharge_power') | int(0) > 0 }}
-          - alias: Do not interrupt (protection) charging
+          - alias: >-
+              Leave the minimum SOC to the SOC protection while that is
+              (re)charging the battery
+            condition: or
+            conditions:
+              - condition: state
+                entity_id: input_boolean.zendure_setting_soc_protection_disabled
+                state:
+                  - "on"
+              - condition: template
+                value_template: |
+                  {{ states('sensor.zendure_total_state_of_charge') | float(0) >=
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) }}
+          - alias: Do not interrupt charging that is already running
             condition: numeric_state
             entity_id: sensor.zendure_power
             below: 30

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -1342,6 +1342,80 @@ actions:
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: During charging balance to -xxx watt (100% of the demand)
+      - conditions:
+          - condition: trigger
+            id:
+              - aansturing_trigger
+          - condition: or
+            conditions:
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state: Smart Matching
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state: Smart Discharge Only
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state:
+                  - Dynamic Smart Matching
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state:
+                  - Dynamic Smart Matching (Expensive)
+              - condition: state
+                entity_id: input_select.zendure_operation_mode
+                state:
+                  - Dynamic Trading + Smart Matching
+          - alias: >-
+              Minimum configured SOC reached or discharge limit reported by the
+              device
+            condition: or
+            conditions:
+              - condition: template
+                value_template: |
+                  {{ states('sensor.zendure_total_state_of_charge') | float(0) <=
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) }}
+              - condition: state
+                entity_id: sensor.zendure_soc_limit_status
+                state:
+                  - Discharge Limit Reached
+          - alias: The device still has a discharge power set
+            condition: template
+            value_template: |
+              {{ states('sensor.zendure_set_discharge_power') | int(0) > 0 }}
+          - alias: Do not interrupt (protection) charging
+            condition: numeric_state
+            entity_id: sensor.zendure_power
+            below: 30
+          - condition: and
+            conditions:
+              - condition: state
+                entity_id: input_boolean.dynamic_charging_running
+                state:
+                  - "off"
+              - condition: state
+                entity_id: input_boolean.dynamic_discharging_running
+                state:
+                  - "off"
+          - alias: Required sensors are available
+            condition: template
+            value_template: >-
+              {{ states('sensor.zendure_total_state_of_charge') not in ['unknown',
+              'unavailable']
+                 and states('sensor.zendure_minimum_state_of_charge') not in ['unknown', 'unavailable']
+                 and states('sensor.zendure_set_discharge_power') not in ['unknown', 'unavailable'] }}
+        sequence:
+          - action: rest_command.zendure_stop_with_discharging
+            data:
+              sn: "{{ states('sensor.zendure_serial_number') }}"
+          - action: logbook.log
+            data:
+              message: >-
+                🛑Minimum state of charge reached — discharge power reset to 0
+                watt —
+              entity_id: input_select.zendure_operation_mode
+              name: " "
+        alias: Stop discharging when the minimum state of charge is reached
   - alias: Manual Control
     choose:
       - conditions:


### PR DESCRIPTION
### First commit

Addresses the over-discharge reported in Gielz1986/Zendure-HA-zenSDK#226 ("SolarFlow 3000 Mix AC+: Smart Matching continues discharging at last set power after reaching SOC limit").

## The problem

Smart Matching only stops *commanding* the battery once the minimum SOC is reached — it never tells it to stop.

Both discharge branches of `Smart Matching Control` are gated on `total_state_of_charge > minimum_state_of_charge` and on `soc_limit_status` being anything other than `Discharge Limit Reached`. Neither writes `outputLimit: 0`; `zendure_x_discharge_balancing` sends only `{"outputLimit": N}`. So when the gate closes, the automation goes quiet and the device is left holding the last value it was given — 648 W in the report — and keeps discharging if its firmware does not enforce `minSoc` itself.

Two gaps follow:

1. **At exactly `SOC == minSoc`, nothing acts.** The discharge branches need `SOC > minSoc`; `Charging to minimum SOC (protection)` needs `SOC < minSoc`, or `SOC == minSoc` *and* a protection charge already running. So no command of any kind is sent until the reported integer SOC drops a further point.
2. **`socLimit = 2` ("Discharge Limit Reached") is ignored.** It appears only as an *allowed* state in the charging branches and never triggers a stop — the device can be reporting that it has hit its floor while HA leaves the setpoint standing.

Dynamic Trading already handles this correctly: it waits for `SOC <= minSoc` and then fires `zendure_stop_with_everything`. Smart Matching had no equivalent.

The device firmware not honouring `minSoc` is the trigger, but the package assumes it always will, and has no fallback in this mode.

## The change

Adds one branch to `Smart Matching Control` (EN) / `NOM Aansturing` (NL), as the **last** branch of the `choose`, so the existing charging branches keep precedence. It fires when:

- the mode is in the Smart Matching family (Smart Matching, Smart Discharge Only, Dynamic Smart Matching, Dynamic Smart Matching (Expensive), Dynamic Trading + Smart Matching); **and**
- `SOC <= minSoc` **or** the device reports `Discharge Limit Reached`; **and**
- the device still reports a discharge power `> 0`; **and**
- the battery is not charging (`power < 30 W`); **and**
- no dynamic charge/discharge run owns the device; **and**
- the SOC / setpoint sensors are neither `unknown` nor `unavailable`.

Action: `rest_command.zendure_stop_with_discharging` (`{"acMode": 2, "outputLimit": 0}`) plus a logbook line.

Design notes:

- **Self-limiting.** The `set_discharge_power > 0` condition means it fires once and goes quiet as soon as the device acknowledges the write — no 5-second command spam. On firmware that already stops at `minSoc` it is a no-op, since the device reports `outputLimit` back as 0.
- **Cannot fight the SOC protection.** The `power < 30 W` condition keeps it from cancelling an in-flight `Charging to minimum SOC (protection)` charge (`acMode: 1, inputLimit: 1200`), which runs from a separate action block.
- **Last in the `choose`.** If PV surplus is available at the floor, the existing charging branches still win; the stop only applies when nothing else would act (e.g. at night).
- Behaviour is independent of the `soc_protection_disabled` toggle, so the floor is now enforced even when the user has handed recovery over to the BMS.

## Files

- `Global (EN) Integration/automation_global.yaml`
- `Dutch (NL) Integration/automation_nl.yaml`

Same logic in both, using each variant's entity IDs, mode labels and rest command names. No package/dashboard changes — `zendure_stop_with_discharging` / `zendure_stop_met_ontladen` already existed and were simply unused on this path.

## Verification

- Both automation files and both package files parse as YAML.
- Every entity ID, `input_select` option label, `soc_limit_status` state string and `rest_command` referenced by the new branch was checked to exist in the corresponding package.
- All new Jinja templates parse; the two gating templates were evaluated against the reported scenario (SOC 10 %, minSoc 10 %, `outputLimit` 648 W) and both return true.

Not verified against live hardware — the reporter's device is the only confirmed case of firmware ignoring `minSoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Second commit, addressing Sourcery's review

`Charging to minimum SOC (protection)` lives in the `System` action block, which is index 1 of the automation's `actions:` list; `Smart Matching Control` is index 2. They execute back to back in the same run with no delay, so when protection writes `acMode: 1, inputLimit: 1200`, the power and setpoint sensors *cannot* have refreshed by the time the stop branch is evaluated — the REST resource polls at `scan_interval: 1` and the automation ticks every 5 s. The stop branch would see a still-negative `zendure_power` and a stale `outputLimit` of 648 W, and write `acMode: 2, outputLimit: 0`, cancelling the protection charge for that tick.

**Fix.** Rather than inferring the charging state from telemetry — any sensor-based signal, `relay_mode` included, has the same same-run staleness — the two branches are now coordinated on the SOC comparison they both already key off. The stop branch stands down whenever the SOC protection is enabled and `SOC < minSoc`, which is exactly the condition under which protection charges:

```yaml
- alias: >-
    Leave the minimum SOC to the SOC protection while that is
    (re)charging the battery
  condition: or
  conditions:
    - condition: state
      entity_id: input_boolean.zendure_setting_soc_protection_disabled
      state: ["on"]
    - condition: template
      value_template: |
        {{ states('sensor.zendure_total_state_of_charge') | float(0) >=
           states('sensor.zendure_minimum_state_of_charge') | float(0) }}
```

`power < 30 W` is kept — it still covers steady-state charging that has already ramped, such as the PV-surplus charging branches earlier in the same `choose`.

**Resulting firing set** (min SOC 10 %), which is exactly the two gaps this PR targets, and nothing else:

| SOC | SOC protection | socLimit | stop fires |
|---|---|---|---|
| 8–9 % | on | any | no — protection charges |
| 8–9 % | off | any | **yes** — nothing else would act |
| 10 % | on or off | any | **yes** — the `SOC == minSoc` dead zone |
| 11 % | either | Discharge Limit Reached | **yes** — device reports its floor |
| 11 % | either | Normal Operation | no |

I enumerated the protection branch's *commanded* power (not merely whether it fires) across SOC × protection-toggle × socLimit × `set_charge_power`: there is now no case where the stop branch cancels an active protection charge. The one remaining co-fire is at `SOC == minSoc` with protection enabled, where protection's own template evaluates `{{ 1200 if soc < min_soc else 0 }}` to **0** — it is ending the protection charge, not starting one. Both commands mean 0 W, the device settles in discharge-stand at 0 W, and on the next tick neither branch re-fires (protection's second clause needs `set_charge_power == 1200`, the stop branch needs `set_discharge_power > 0`). No oscillation.

Re-verified after the change: both automation files parse, and every entity ID, option label and rest command in the branch still resolves against its package.
