### PR TITLE
Give float/int filters explicit defaults and guard unavailable entities

### DIFF
--- a/Dutch (NL) Integration/automation_nl.yaml
+++ b/Dutch (NL) Integration/automation_nl.yaml
@@ -200,7 +200,7 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_ontlaadvermogen') |
-                int }}
+                int(0) }}
         alias: Snel ontladen
       - conditions:
           - condition: trigger
@@ -215,7 +215,7 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                int(0) }}
         alias: Snel opladen
   - alias: Systeem
     choose:
@@ -296,15 +296,20 @@ actions:
             conditions:
               - condition: template
                 value_template: |
-                  {{ (states('sensor.zendure_2400_ac_laadpercentage') | float) <
-                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float }}
+                  {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                  and (states('sensor.zendure_2400_ac_laadpercentage') | float(0)) <
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
               - condition: template
                 value_template: >
-                  {{ (states('sensor.zendure_2400_ac_laadpercentage') | float |
+                  {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_ingesteld_oplaadvermogen')
+                  and (states('sensor.zendure_2400_ac_laadpercentage') | float(0) |
                   round(0) ==
-                      states('sensor.zendure_2400_ac_minimale_laadpercentage') | float | round(0))
+                      states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) | round(0))
                      and
-                     (states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | float == 1200) }}
+                     (states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | float(0) == 1200) }}
             alias: SOC komt niet overeen met minimaal ingestelde SOC
           - condition: or
             conditions:
@@ -360,8 +365,8 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >
                 {% set soc = states('sensor.zendure_2400_ac_laadpercentage') |
-                float | round(0) %} {% set min_soc =
-                states('sensor.zendure_2400_ac_minimale_laadpercentage') | float
+                float(0) | round(0) %} {% set min_soc =
+                states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0)
                 | round(0) %} {{ 1200 if soc < min_soc else 0 }}
             action: rest_command.zendure_x_laden
           - action: logbook.log
@@ -369,9 +374,9 @@ actions:
               message: >
                 ⚠️Batterij SOC bescherming actief — Vermogen ingesteld op   {%
                 set soc = states('sensor.zendure_2400_ac_laadpercentage') |
-                float |
+                float(0) |
                   round(0) %} {% set min_soc =
-                  states('sensor.zendure_2400_ac_minimale_laadpercentage') | float | round(0) %}
+                  states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) | round(0) %}
                   {{ 1200 if soc < min_soc else 0 }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -388,27 +393,32 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{
+                      {{ has_value('sensor.zendure_2400_ac_omvormer_max_oplaadvermogen')
+                      and has_value('input_number.zendure_2400_ac_max_oplaadvermogen')
+                      and
                       states('sensor.zendure_2400_ac_omvormer_max_oplaadvermogen')
-                      | float !=
+                      | float(0) !=
                       states('input_number.zendure_2400_ac_max_oplaadvermogen')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: De instelling heeft een waarde
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_2400_ac_max_oplaadvermogen') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               instellingitem: chargeMaxLimit
               instellinginhoud: >-
                 {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                int(0) }}
             action: rest_command.zendure_instelling
           - action: logbook.log
             data:
               message: >
                 ⚙️Maximaal oplaadvermogen aangepast naar {{
-                states('input_number.zendure_2400_ac_max_oplaadvermogen') | int
+                states('input_number.zendure_2400_ac_max_oplaadvermogen') | int(0)
                 }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -425,27 +435,32 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{
+                      {{ has_value('sensor.zendure_2400_ac_omvormer_max_ontlaadvermogen')
+                      and has_value('input_number.zendure_2400_ac_max_ontlaadvermogen')
+                      and
                       states('sensor.zendure_2400_ac_omvormer_max_ontlaadvermogen')
-                      | float !=
+                      | float(0) !=
                       states('input_number.zendure_2400_ac_max_ontlaadvermogen')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: De instelling heeft een waarde
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_2400_ac_max_ontlaadvermogen') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               instellingitem: inverseMaxPower
               instellinginhoud: >-
                 {{ states('input_number.zendure_2400_ac_max_ontlaadvermogen') |
-                int }}
+                int(0) }}
             action: rest_command.zendure_instelling
           - action: logbook.log
             data:
               message: >
                 ⚙️Maximaal ontlaadvermogen aangepast naar {{
-                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | int
+                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | int(0)
                 }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -462,14 +477,19 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{
+                      {{ has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                      and has_value('input_number.zendure_2400_ac_minimaal_toegestaan_laadpercentage')
+                      and
                       states('sensor.zendure_2400_ac_minimale_laadpercentage') |
-                      float !=
+                      float(0) !=
                       states('input_number.zendure_2400_ac_minimaal_toegestaan_laadpercentage')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: De instelling heeft een waarde
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_2400_ac_minimaal_toegestaan_laadpercentage') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
@@ -484,7 +504,7 @@ actions:
               message: >
                 ⚙️Minimaal toegestaan laadpercentage aangepast naar {{
                 states('input_number.zendure_2400_ac_minimaal_toegestaan_laadpercentage')
-                | int }}% —
+                | int(0) }}% —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Minimaal toegestane laadpercentage aanpassen
@@ -500,14 +520,19 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{
+                      {{ has_value('sensor.zendure_2400_ac_maximale_laadpercentage')
+                      and has_value('input_number.zendure_2400_ac_maximaal_toegestaan_laadpercentage')
+                      and
                       states('sensor.zendure_2400_ac_maximale_laadpercentage') |
-                      float !=
+                      float(0) !=
                       states('input_number.zendure_2400_ac_maximaal_toegestaan_laadpercentage')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: De instelling heeft een waarde
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_2400_ac_maximaal_toegestaan_laadpercentage') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
@@ -522,7 +547,7 @@ actions:
               message: >
                 ⚙️Maximaal toegestaan laadpercentage aangepast naar {{
                 states('input_number.zendure_2400_ac_maximaal_toegestaan_laadpercentage')
-                | int }}% —
+                | int(0) }}% —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Maximaal toegestane laadpercentage aanpassen
@@ -679,9 +704,11 @@ actions:
               - aansturing_trigger
           - condition: template
             value_template: >-
-              {{ states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') |
-              float != states('input_number.zendure_2400_ac_max_oplaadvermogen')
-              | float }}
+              {{ has_value('sensor.zendure_2400_ac_ingesteld_oplaadvermogen')
+              and has_value('input_number.zendure_2400_ac_max_oplaadvermogen')
+              and states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') |
+              float(0) != states('input_number.zendure_2400_ac_max_oplaadvermogen')
+              | float(0) }}
           - condition: or
             conditions:
               - condition: state
@@ -706,12 +733,12 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: >
                 ⚙️Huidig oplaadvermogen gecorrigeerd naar {{
-                states('input_number.zendure_2400_ac_max_oplaadvermogen') | int
+                states('input_number.zendure_2400_ac_max_oplaadvermogen') | int(0)
                 }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -722,9 +749,11 @@ actions:
               - aansturing_trigger
           - condition: template
             value_template: >-
-              {{ states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') |
-              float !=
-              states('input_number.zendure_2400_ac_max_ontlaadvermogen') | float
+              {{ has_value('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen')
+              and has_value('input_number.zendure_2400_ac_max_ontlaadvermogen')
+              and states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') |
+              float(0) !=
+              states('input_number.zendure_2400_ac_max_ontlaadvermogen') | float(0)
               }}
           - condition: or
             conditions:
@@ -750,12 +779,12 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_ontlaadvermogen') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: >
                 ⚙️Huidig ontlaadvermogen gecorrigeerd naar {{
-                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | int
+                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | int(0)
                 }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -914,8 +943,10 @@ actions:
           - alias: Tot de minimaal ingestelde SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_2400_ac_laadpercentage') | float >
-               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float }}
+              {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+              and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+              and states('sensor.zendure_2400_ac_laadpercentage') | float(0) >
+               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
           - condition: numeric_state
             entity_id: sensor.zendure_2400_ac_vermogen_aansturing
             above: -30
@@ -969,8 +1000,10 @@ actions:
                       zijn aan input_number.dynamisch_minimale_spread
                     condition: template
                     value_template: >-
-                      {{ states('sensor.dynamisch_spread_indicatie') | float >=
-                      states('input_number.dynamisch_minimale_spread') | float
+                      {{ has_value('sensor.dynamisch_spread_indicatie')
+                      and has_value('input_number.dynamisch_minimale_spread')
+                      and states('sensor.dynamisch_spread_indicatie') | float(0) >=
+                      states('input_number.dynamisch_minimale_spread') | float(0)
                       }}
           - condition: and
             conditions:
@@ -1005,7 +1038,7 @@ actions:
                 {% set totaal = (p1 - zendure - correctie) * factor %} {% set
                 beperkt = [ [totaal, 0] | max, cap ] | min %}
 
-                {{ beperkt | int }}
+                {{ beperkt | int(0) }}
             action: rest_command.zendure_x_ontladen
           - action: logbook.log
             data:
@@ -1018,7 +1051,7 @@ actions:
                   {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %}
 
                   {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [
-                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int }} watt —
+                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Start met ontladen bij +xxx watt (75% van de vraag)
@@ -1035,15 +1068,17 @@ actions:
           - alias: Tot de minimaal ingestelde SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_2400_ac_laadpercentage') | float >
-               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float }}
+              {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+              and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+              and states('sensor.zendure_2400_ac_laadpercentage') | float(0) >
+               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
           - alias: >-
               Nieuw in te stellen vermogen is anders dan huidig batterij
               vermogen
             condition: template
             value_template: |-
               {% set factor = 1.00 %} {% set cap =
-                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | float(0) %} {% set correctie = -1 * (states('input_number.zendure_2400_ac_ontlaadmarge') | float(0)) %} {% set p1 = states('sensor.p1_aansturing_vermogen') | float(0) %} {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %} {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [ [totaal, 0] | max, cap ] | min %} {% set target = beperkt | int %} {% set huidig = states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int(0) %} {{ huidig != target }}
+                states('input_number.zendure_2400_ac_max_ontlaadvermogen') | float(0) %} {% set correctie = -1 * (states('input_number.zendure_2400_ac_ontlaadmarge') | float(0)) %} {% set p1 = states('sensor.p1_aansturing_vermogen') | float(0) %} {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %} {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [ [totaal, 0] | max, cap ] | min %} {% set target = beperkt | int(0) %} {% set huidig = states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int(0) %} {{ huidig != target }}
           - condition: numeric_state
             entity_id: sensor.zendure_2400_ac_vermogen_aansturing
             below: 0
@@ -1080,8 +1115,10 @@ actions:
                       zijn aan input_number.dynamisch_minimale_spread
                     condition: template
                     value_template: >-
-                      {{ states('sensor.dynamisch_spread_indicatie') | float >=
-                      states('input_number.dynamisch_minimale_spread') | float
+                      {{ has_value('sensor.dynamisch_spread_indicatie')
+                      and has_value('input_number.dynamisch_minimale_spread')
+                      and states('sensor.dynamisch_spread_indicatie') | float(0) >=
+                      states('input_number.dynamisch_minimale_spread') | float(0)
                       }}
           - condition: and
             conditions:
@@ -1114,7 +1151,7 @@ actions:
                 %}
 
                 {% set totaal = (p1 - zendure - correctie) * factor %} {% set
-                beperkt = [ [totaal, 0] | max, cap ] | min %} {{ beperkt | int
+                beperkt = [ [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0)
                 }}
             action: rest_command.zendure_x_ontladen_balanceren
           - action: logbook.log
@@ -1128,7 +1165,7 @@ actions:
                   {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %}
 
                   {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [
-                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int }} watt —
+                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Tijdens ontladen balanceren naar -xxx watt (100% van de vraag)
@@ -1162,9 +1199,11 @@ actions:
             conditions:
               - condition: template
                 value_template: >
-                  {{ states('sensor.zendure_2400_ac_laadpercentage') | float |
+                  {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                  and states('sensor.zendure_2400_ac_laadpercentage') | float(0) |
                   round(0) >=
-                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float | round(0) }}
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) | round(0) }}
                 alias: SOC is gelijk of groter dan de minimale SOC
               - condition: state
                 entity_id: input_boolean.zendure_2400_ac_soc_bescherming_uitgeschakeld
@@ -1236,7 +1275,7 @@ actions:
                 states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0)
                 %} {% set verschil = zendure - p1 - correctie_export %} {% set
                 beperkt = verschil * factor if verschil > 0 else 0 %} {% set
-                beperkt = beperkt if beperkt < cap else cap %} {{ beperkt | int
+                beperkt = beperkt if beperkt < cap else cap %} {{ beperkt | int(0)
                 }}
             action: rest_command.zendure_x_laden
           - action: logbook.log
@@ -1251,7 +1290,7 @@ actions:
                   {% set verschil = zendure - p1 - correctie_export %}
                   {% set beperkt = verschil * factor if verschil > 0 else 0 %}
                   {% set beperkt = beperkt if beperkt < cap else cap %}
-                  {{ beperkt | int }} watt —
+                  {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Start met opladen bij -xxx watt (75% van aanbod)
@@ -1271,7 +1310,7 @@ actions:
             condition: template
             value_template: |-
               {% set factor = 1.00 %} {% set cap =
-                states('input_number.zendure_2400_ac_max_oplaadvermogen') | float(0) %} {% set correctie_export = states('input_number.zendure_2400_ac_oplaadmarge') | float(0) %} {% set p1 = states('sensor.p1_aansturing_vermogen') | float(0) %} {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %} {% set verschil = (zendure - p1 - correctie_export) * factor %} {% set beperkt = [ [verschil, 0] | max, cap ] | min %} {% set target = beperkt | int %} {% set huidig = states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | int(0) %} {{ huidig != target }}
+                states('input_number.zendure_2400_ac_max_oplaadvermogen') | float(0) %} {% set correctie_export = states('input_number.zendure_2400_ac_oplaadmarge') | float(0) %} {% set p1 = states('sensor.p1_aansturing_vermogen') | float(0) %} {% set zendure = states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0) %} {% set verschil = (zendure - p1 - correctie_export) * factor %} {% set beperkt = [ [verschil, 0] | max, cap ] | min %} {% set target = beperkt | int(0) %} {% set huidig = states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | int(0) %} {{ huidig != target }}
           - alias: Lager dan maximaal ingestelde SOC
             condition: template
             value_template: |2-
@@ -1286,9 +1325,11 @@ actions:
             conditions:
               - condition: template
                 value_template: >
-                  {{ states('sensor.zendure_2400_ac_laadpercentage') | float |
+                  {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                  and states('sensor.zendure_2400_ac_laadpercentage') | float(0) |
                   round(0) >=
-                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float | round(0) }}
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) | round(0) }}
                 alias: SOC is gelijk of groter dan de minimale SOC
               - condition: state
                 entity_id: input_boolean.zendure_2400_ac_soc_bescherming_uitgeschakeld
@@ -1343,7 +1384,7 @@ actions:
                 states('sensor.zendure_2400_ac_vermogen_aansturing') | float(0)
                 %} {% set verschil = zendure - p1 - correctie_export %} {% set
                 beperkt = verschil * factor if verschil > 0 else 0 %} {% set
-                beperkt = beperkt if beperkt < cap else cap %} {{ beperkt | int
+                beperkt = beperkt if beperkt < cap else cap %} {{ beperkt | int(0)
                 }}
             action: rest_command.zendure_x_laden_balanceren
           - action: logbook.log
@@ -1358,7 +1399,7 @@ actions:
                   {% set verschil = zendure - p1 - correctie_export %}
                   {% set beperkt = verschil * factor if verschil > 0 else 0 %}
                   {% set beperkt = beperkt if beperkt < cap else cap %}
-                  {{ beperkt | int }} watt —
+                  {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
         alias: Tijdens opladen balanceren naar -xxx watt (100% van aanbod)
@@ -1381,21 +1422,23 @@ actions:
             above: -1
           - condition: template
             value_template: >-
-              {{ states('input_number.zendure_2400_ac_handmatig_vermogen') | int
+              {{ has_value('input_number.zendure_2400_ac_handmatig_vermogen')
+              and has_value('sensor.zendure_2400_ac_ingesteld_oplaadvermogen')
+              and states('input_number.zendure_2400_ac_handmatig_vermogen') | int(0)
               | abs !=
-                 states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | int }}
+                 states('sensor.zendure_2400_ac_ingesteld_oplaadvermogen') | int(0) }}
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
                 {{ states('input_number.zendure_2400_ac_handmatig_vermogen') |
-                int | abs }}
+                int(0) | abs }}
             action: rest_command.zendure_x_laden
           - action: logbook.log
             data:
               message: >
                 ⚡Handmatig laden — Vermogen ingesteld op {{
-                states('input_number.zendure_2400_ac_handmatig_vermogen') | int
+                states('input_number.zendure_2400_ac_handmatig_vermogen') | int(0)
                 | abs }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -1417,21 +1460,23 @@ actions:
             below: 1
           - condition: template
             value_template: >-
-              {{ states('input_number.zendure_2400_ac_handmatig_vermogen') | int
+              {{ has_value('input_number.zendure_2400_ac_handmatig_vermogen')
+              and has_value('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen')
+              and states('input_number.zendure_2400_ac_handmatig_vermogen') | int(0)
               | abs !=
-                 states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int }}
+                 states('sensor.zendure_2400_ac_ingesteld_ontlaadvermogen') | int(0) }}
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_2400_ac_handmatig_vermogen') |
-                int | abs }}
+                int(0) | abs }}
             action: rest_command.zendure_x_ontladen
           - action: logbook.log
             data:
               message: >
                 ⚡Handmatig ontladen — Vermogen ingesteld op {{
-                states('input_number.zendure_2400_ac_handmatig_vermogen') | int
+                states('input_number.zendure_2400_ac_handmatig_vermogen') | int(0)
                 | abs }} watt —
               entity_id: input_select.zendure_2400_ac_modus_selecteren
               name: " "
@@ -1455,7 +1500,7 @@ actions:
             data:
               value: >-
                 {{ states('input_number.dynamisch_goedkoopste_x_periode_morgen')
-                | float }}
+                | float(0) }}
             action: input_number.set_value
           - alias: Zet duurste periode van morgen naar vandaag
             target:
@@ -1463,7 +1508,7 @@ actions:
             data:
               value: >-
                 {{ states('input_number.dynamisch_duurste_x_periode_morgen') |
-                float }}
+                float(0) }}
             action: input_number.set_value
           - alias: Zet handmatige periode van morgen naar vandaag
             target:
@@ -1611,8 +1656,10 @@ actions:
               aan input_number.dynamisch_minimale_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamisch_spread_indicatie_nom') | float >=
-              states('input_number.dynamisch_minimale_spread') | float }}
+              {{ has_value('sensor.dynamisch_spread_indicatie_nom')
+              and has_value('input_number.dynamisch_minimale_spread')
+              and states('sensor.dynamisch_spread_indicatie_nom') | float(0) >=
+              states('input_number.dynamisch_minimale_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamisch_laden_loopt
             state:
@@ -1636,7 +1683,7 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: 💲Dynamisch NOM goedkoop laden gestart —
@@ -1731,8 +1778,10 @@ actions:
               input_number.dynamisch_minimale_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamisch_spread_indicatie') | float >=
-              states('input_number.dynamisch_minimale_spread') | float }}
+              {{ has_value('sensor.dynamisch_spread_indicatie')
+              and has_value('input_number.dynamisch_minimale_spread')
+              and states('sensor.dynamisch_spread_indicatie') | float(0) >=
+              states('input_number.dynamisch_minimale_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamisch_laden_loopt
             state:
@@ -1756,7 +1805,7 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               inputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_oplaadvermogen') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: 💲Dynamisch goedkoop laden gestart —
@@ -1833,8 +1882,10 @@ actions:
           - alias: Tot de minimaal ingestelde SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_2400_ac_laadpercentage') | float >
-               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float }}
+              {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+              and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+              and states('sensor.zendure_2400_ac_laadpercentage') | float(0) >
+               states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
           - condition: state
             entity_id: sensor.dynamisch_duurste_periode
             state:
@@ -1844,8 +1895,10 @@ actions:
               input_number.dynamisch_minimale_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamisch_spread_indicatie') | float >=
-              states('input_number.dynamisch_minimale_spread') | float }}
+              {{ has_value('sensor.dynamisch_spread_indicatie')
+              and has_value('input_number.dynamisch_minimale_spread')
+              and states('sensor.dynamisch_spread_indicatie') | float(0) >=
+              states('input_number.dynamisch_minimale_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamisch_ontladen_loopt
             state:
@@ -1869,7 +1922,7 @@ actions:
               sn: "{{ states('sensor.zendure_2400_ac_serienummer') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_2400_ac_max_ontlaadvermogen') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: 💲Dynamisch duur ontladen gestart —
@@ -1879,8 +1932,10 @@ actions:
               - alias: Tot minimale SOC
                 trigger: template
                 value_template: |-
-                  {{ states('sensor.zendure_2400_ac_laadpercentage') | float <=
-                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float }}
+                  {{ has_value('sensor.zendure_2400_ac_laadpercentage')
+                  and has_value('sensor.zendure_2400_ac_minimale_laadpercentage')
+                  and states('sensor.zendure_2400_ac_laadpercentage') | float(0) <=
+                     states('sensor.zendure_2400_ac_minimale_laadpercentage') | float(0) }}
                 for:
                   hours: 0
                   minutes: 0

--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -941,7 +941,7 @@ template:
         state: >
           {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
           {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-          {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
+          {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int(0) %}
           {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
           {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
           {% if prijzen is iterable %}
@@ -1001,8 +1001,8 @@ template:
           raw_today: >
             {% set prijzen = state_attr('sensor.dynamisch_goedkoopste_periode', 'raw_today') %}
             {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int(0) %}
             {% if prijzen is iterable %}
               {% set ns = namespace(goede_starttijden=[], dure_starttijden=[]) %}
               {% if handmatige | length > 0 %}
@@ -1049,7 +1049,7 @@ template:
         state: >
           {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
           {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-          {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
+          {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int(0) %}
           {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
           {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
           {% if prijzen is iterable %}
@@ -1105,8 +1105,8 @@ template:
           raw_today: >
             {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_today') %}
             {% set handmatige = states('input_text.dynamisch_handmatige_periode') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode') | int(0) %}
             {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
             {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
             {% if prijzen is iterable %}
@@ -1173,8 +1173,8 @@ template:
           raw_tomorrow: >
             {% set prijzen = state_attr('sensor.dynamisch_nordpool', 'raw_tomorrow') %}
             {% set handmatige = states('input_text.dynamisch_handmatige_periode_morgen') %}
-            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode_morgen') | int %}
-            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode_morgen') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamisch_goedkoopste_x_periode_morgen') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamisch_duurste_x_periode_morgen') | int(0) %}
             {% set kwartier = is_state('input_boolean.dynamisch_15_minuten', 'on') %}
             {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
             {% if prijzen is iterable %}

--- a/Global (EN) Integration/automation_global.yaml
+++ b/Global (EN) Integration/automation_global.yaml
@@ -201,7 +201,7 @@ actions:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_setting_max_discharge_power') |
-                int }}
+                int(0) }}
         alias: Quick Discharge
       - conditions:
           - condition: trigger
@@ -215,7 +215,7 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
+                {{ states('input_number.zendure_setting_max_charge_power') | int(0)
                 }}
         alias: Quick Charge
   - alias: System
@@ -297,15 +297,20 @@ actions:
             conditions:
               - condition: template
                 value_template: |
-                  {{ (states('sensor.zendure_total_state_of_charge') | float) <
-                     states('sensor.zendure_minimum_state_of_charge') | float }}
+                  {{ has_value('sensor.zendure_total_state_of_charge')
+                  and has_value('sensor.zendure_minimum_state_of_charge')
+                  and (states('sensor.zendure_total_state_of_charge') | float(0)) <
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) }}
               - condition: template
                 value_template: >
-                  {{ (states('sensor.zendure_total_state_of_charge') | float |
+                  {{ has_value('sensor.zendure_total_state_of_charge')
+                  and has_value('sensor.zendure_minimum_state_of_charge')
+                  and has_value('sensor.zendure_set_charge_power')
+                  and (states('sensor.zendure_total_state_of_charge') | float(0) |
                   round(0) ==
-                      states('sensor.zendure_minimum_state_of_charge') | float | round(0))
+                      states('sensor.zendure_minimum_state_of_charge') | float(0) | round(0))
                      and
-                     (states('sensor.zendure_set_charge_power') | float == 1200) }}
+                     (states('sensor.zendure_set_charge_power') | float(0) == 1200) }}
             alias: SOC does not match minimum configured SOC
           - condition: or
             conditions:
@@ -362,17 +367,17 @@ actions:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >
                 {% set soc = states('sensor.zendure_total_state_of_charge') |
-                float | round(0) %} {% set min_soc =
-                states('sensor.zendure_minimum_state_of_charge') | float |
+                float(0) | round(0) %} {% set min_soc =
+                states('sensor.zendure_minimum_state_of_charge') | float(0) |
                 round(0) %} {{ 1200 if soc < min_soc else 0 }}
             action: rest_command.zendure_x_charge
           - action: logbook.log
             data:
               message: >
                 ⚠️Battery SOC protection active — Power set to {% set soc =
-                states('sensor.zendure_total_state_of_charge') | float |
+                states('sensor.zendure_total_state_of_charge') | float(0) |
                   round(0) %} {% set min_soc =
-                  states('sensor.zendure_minimum_state_of_charge') | float | round(0) %}
+                  states('sensor.zendure_minimum_state_of_charge') | float(0) | round(0) %}
                   {{ 1200 if soc < min_soc else 0 }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -389,13 +394,18 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.zendure_maximum_state_of_charge') |
-                      float !=
+                      {{ has_value('sensor.zendure_maximum_state_of_charge')
+                      and has_value('input_number.zendure_setting_maximum_allowed_state_of_charge')
+                      and states('sensor.zendure_maximum_state_of_charge') |
+                      float(0) !=
                       states('input_number.zendure_setting_maximum_allowed_state_of_charge')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: The setting has a value
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_setting_maximum_allowed_state_of_charge') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
@@ -410,7 +420,7 @@ actions:
               message: >
                 ⚙️Maximum allowed state of charge adjusted to {{
                 states('input_number.zendure_setting_maximum_allowed_state_of_charge')
-                | int }}% —
+                | int(0) }}% —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: Adjust maximum allowed state of charge
@@ -426,13 +436,18 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.zendure_minimum_state_of_charge') |
-                      float !=
+                      {{ has_value('sensor.zendure_minimum_state_of_charge')
+                      and has_value('input_number.zendure_setting_minimum_allowed_state_of_charge')
+                      and states('sensor.zendure_minimum_state_of_charge') |
+                      float(0) !=
                       states('input_number.zendure_setting_minimum_allowed_state_of_charge')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: The setting has a value
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_setting_minimum_allowed_state_of_charge') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
@@ -447,7 +462,7 @@ actions:
               message: >
                 ⚙️Minimum allowed state of charge adjusted to {{
                 states('input_number.zendure_setting_minimum_allowed_state_of_charge')
-                | int }}% —
+                | int(0) }}% —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: Adjust minimum allowed state of charge
@@ -463,26 +478,31 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.zendure_inverter_max_charge_power') |
-                      float !=
+                      {{ has_value('sensor.zendure_inverter_max_charge_power')
+                      and has_value('input_number.zendure_setting_max_charge_power')
+                      and states('sensor.zendure_inverter_max_charge_power') |
+                      float(0) !=
                       states('input_number.zendure_setting_max_charge_power') |
-                      float }}
+                      float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: The setting has a value
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_setting_max_charge_power') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               instellingitem: chargeMaxLimit
               instellinginhoud: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
+                {{ states('input_number.zendure_setting_max_charge_power') | int(0)
                 }}
             action: rest_command.zendure_setting
           - action: logbook.log
             data:
               message: >
                 ⚙️Maximum charging power adjusted to {{
-                states('input_number.zendure_setting_max_charge_power') | int }}
+                states('input_number.zendure_setting_max_charge_power') | int(0) }}
                 watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -499,26 +519,31 @@ actions:
                 conditions:
                   - condition: template
                     value_template: >-
-                      {{ states('sensor.zendure_inverter_max_discharge_power') |
-                      float !=
+                      {{ has_value('sensor.zendure_inverter_max_discharge_power')
+                      and has_value('input_number.zendure_setting_max_discharge_power')
+                      and states('sensor.zendure_inverter_max_discharge_power') |
+                      float(0) !=
                       states('input_number.zendure_setting_max_discharge_power')
-                      | float }}
+                      | float(0) }}
                   - condition: trigger
                     id:
                       - aansturing_trigger
+          - alias: The setting has a value
+            condition: template
+            value_template: "{{ has_value('input_number.zendure_setting_max_discharge_power') }}"
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               instellingitem: inverseMaxPower
               instellinginhoud: >-
                 {{ states('input_number.zendure_setting_max_discharge_power') |
-                int }}
+                int(0) }}
             action: rest_command.zendure_setting
           - action: logbook.log
             data:
               message: >
                 ⚙️Maximum discharge power adjusted to {{
-                states('input_number.zendure_setting_max_discharge_power') | int
+                states('input_number.zendure_setting_max_discharge_power') | int(0)
                 }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -671,8 +696,10 @@ actions:
               - aansturing_trigger
           - condition: template
             value_template: >-
-              {{ states('sensor.zendure_set_charge_power') | float !=
-              states('input_number.zendure_setting_max_charge_power') | float }}
+              {{ has_value('sensor.zendure_set_charge_power')
+              and has_value('input_number.zendure_setting_max_charge_power')
+              and states('sensor.zendure_set_charge_power') | float(0) !=
+              states('input_number.zendure_setting_max_charge_power') | float(0) }}
           - condition: or
             conditions:
               - condition: state
@@ -696,13 +723,13 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
+                {{ states('input_number.zendure_setting_max_charge_power') | int(0)
                 }}
           - action: logbook.log
             data:
               message: >
                 ⚙️Current charging power corrected to {{
-                states('input_number.zendure_setting_max_charge_power') | int }}
+                states('input_number.zendure_setting_max_charge_power') | int(0) }}
                 watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -713,8 +740,10 @@ actions:
               - aansturing_trigger
           - condition: template
             value_template: >-
-              {{ states('sensor.zendure_set_discharge_power') | float !=
-              states('input_number.zendure_setting_max_discharge_power') | float
+              {{ has_value('sensor.zendure_set_discharge_power')
+              and has_value('input_number.zendure_setting_max_discharge_power')
+              and states('sensor.zendure_set_discharge_power') | float(0) !=
+              states('input_number.zendure_setting_max_discharge_power') | float(0)
               }}
           - condition: or
             conditions:
@@ -740,12 +769,12 @@ actions:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_setting_max_discharge_power') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: >
                 ⚙️Current discharge power corrected to {{
-                states('input_number.zendure_setting_max_discharge_power') | int
+                states('input_number.zendure_setting_max_discharge_power') | int(0)
                 }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -902,8 +931,10 @@ actions:
           - alias: Down to the minimum configured SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_total_state_of_charge') | float >
-               states('sensor.zendure_minimum_state_of_charge') | float }}
+              {{ has_value('sensor.zendure_total_state_of_charge')
+              and has_value('sensor.zendure_minimum_state_of_charge')
+              and states('sensor.zendure_total_state_of_charge') | float(0) >
+               states('sensor.zendure_minimum_state_of_charge') | float(0) }}
           - condition: numeric_state
             entity_id: sensor.zendure_power
             above: -30
@@ -957,9 +988,11 @@ actions:
                       input_number.dynamic_setting_minimal_spread
                     condition: template
                     value_template: >-
-                      {{ states('sensor.dynamic_spread_indication') | float >=
+                      {{ has_value('sensor.dynamic_spread_indication')
+                      and has_value('input_number.dynamic_setting_minimal_spread')
+                      and states('sensor.dynamic_spread_indication') | float(0) >=
                       states('input_number.dynamic_setting_minimal_spread') |
-                      float }}
+                      float(0) }}
           - condition: and
             conditions:
               - condition: state
@@ -992,7 +1025,7 @@ actions:
                 {% set totaal = (p1 - zendure - correctie) * factor %} {% set
                 beperkt = [ [totaal, 0] | max, cap ] | min %}
 
-                {{ beperkt | int }}
+                {{ beperkt | int(0) }}
             action: rest_command.zendure_x_discharge
           - action: logbook.log
             data:
@@ -1004,7 +1037,7 @@ actions:
                   {% set zendure = states('sensor.zendure_power') | float(0) %}
 
                   {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [
-                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int }} watt —
+                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: Start discharging at +xxx watt (75% of demand)
@@ -1021,15 +1054,17 @@ actions:
           - alias: Down to the minimum configured SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_total_state_of_charge') | float >
-               states('sensor.zendure_minimum_state_of_charge') | float }}
+              {{ has_value('sensor.zendure_total_state_of_charge')
+              and has_value('sensor.zendure_minimum_state_of_charge')
+              and states('sensor.zendure_total_state_of_charge') | float(0) >
+               states('sensor.zendure_minimum_state_of_charge') | float(0) }}
           - alias: >-
               The new power to be set is different from the current battery
               power
             condition: template
             value_template: |-
               {% set factor = 1.00 %} {% set cap =
-                states('input_number.zendure_setting_max_discharge_power') | float(0) %} {% set correctie = -1 * (states('input_number.zendure_setting_discharge_buffer') | float(0)) %} {% set p1 = states('sensor.home_energy_meter_power') | float(0) %} {% set zendure = states('sensor.zendure_power') | float(0) %} {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [ [totaal, 0] | max, cap ] | min %} {% set target = beperkt | int %} {% set huidig = states('sensor.zendure_set_discharge_power') | int(0) %} {{ huidig != target }}
+                states('input_number.zendure_setting_max_discharge_power') | float(0) %} {% set correctie = -1 * (states('input_number.zendure_setting_discharge_buffer') | float(0)) %} {% set p1 = states('sensor.home_energy_meter_power') | float(0) %} {% set zendure = states('sensor.zendure_power') | float(0) %} {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [ [totaal, 0] | max, cap ] | min %} {% set target = beperkt | int(0) %} {% set huidig = states('sensor.zendure_set_discharge_power') | int(0) %} {{ huidig != target }}
           - condition: numeric_state
             entity_id: sensor.zendure_power
             below: 0
@@ -1066,9 +1101,11 @@ actions:
                       input_number.dynamic_setting_minimal_spread
                     condition: template
                     value_template: >-
-                      {{ states('sensor.dynamic_spread_indication') | float >=
+                      {{ has_value('sensor.dynamic_spread_indication')
+                      and has_value('input_number.dynamic_setting_minimal_spread')
+                      and states('sensor.dynamic_spread_indication') | float(0) >=
                       states('input_number.dynamic_setting_minimal_spread') |
-                      float }}
+                      float(0) }}
           - condition: and
             conditions:
               - condition: state
@@ -1099,7 +1136,7 @@ actions:
                 zendure = states('sensor.zendure_power') | float(0) %}
 
                 {% set totaal = (p1 - zendure - correctie) * factor %} {% set
-                beperkt = [ [totaal, 0] | max, cap ] | min %} {{ beperkt | int
+                beperkt = [ [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0)
                 }}
             action: rest_command.zendure_x_discharge_balancing
           - action: logbook.log
@@ -1112,7 +1149,7 @@ actions:
                   {% set zendure = states('sensor.zendure_power') | float(0) %}
 
                   {% set totaal = (p1 - zendure - correctie) * factor %} {% set beperkt = [
-                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int }} watt —
+                  [totaal, 0] | max, cap ] | min %} {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: During discharge balance to +xxx watt (100% of the demand)
@@ -1146,9 +1183,11 @@ actions:
             conditions:
               - condition: template
                 value_template: >
-                  {{ states('sensor.zendure_total_state_of_charge') | float |
+                  {{ has_value('sensor.zendure_total_state_of_charge')
+                  and has_value('sensor.zendure_minimum_state_of_charge')
+                  and states('sensor.zendure_total_state_of_charge') | float(0) |
                   round(0) >=
-                     states('sensor.zendure_minimum_state_of_charge') | float | round(0) }}
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) | round(0) }}
                 alias: SOC is gelijk of groter dan de minimale SOC
               - condition: state
                 entity_id: input_boolean.zendure_setting_soc_protection_disabled
@@ -1220,7 +1259,7 @@ actions:
                 float(0) %} {% set verschil = zendure - p1 - correctie_export %}
                 {% set beperkt = verschil * factor if verschil > 0 else 0 %} {%
                 set beperkt = beperkt if beperkt < cap else cap %} {{ beperkt |
-                int }}
+                int(0) }}
             action: rest_command.zendure_x_charge
           - action: logbook.log
             data:
@@ -1233,7 +1272,7 @@ actions:
                   {% set verschil = zendure - p1 - correctie_export %}
                   {% set beperkt = verschil * factor if verschil > 0 else 0 %}
                   {% set beperkt = beperkt if beperkt < cap else cap %}
-                  {{ beperkt | int }} watt —
+                  {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: " Start charging at -xxx watt (75% of demand)"
@@ -1253,7 +1292,7 @@ actions:
             condition: template
             value_template: |-
               {% set factor = 1.00 %} {% set cap =
-                states('input_number.zendure_setting_max_charge_power') | float(0) %} {% set correctie_export = states('input_number.zendure_setting_charge_buffer') | float(0) %} {% set p1 = states('sensor.home_energy_meter_power') | float(0) %} {% set zendure = states('sensor.zendure_power') | float(0) %} {% set verschil = (zendure - p1 - correctie_export) * factor %} {% set beperkt = [ [verschil, 0] | max, cap ] | min %} {% set target = beperkt | int %} {% set huidig = states('sensor.zendure_set_charge_power') | int(0) %} {{ huidig != target }}
+                states('input_number.zendure_setting_max_charge_power') | float(0) %} {% set correctie_export = states('input_number.zendure_setting_charge_buffer') | float(0) %} {% set p1 = states('sensor.home_energy_meter_power') | float(0) %} {% set zendure = states('sensor.zendure_power') | float(0) %} {% set verschil = (zendure - p1 - correctie_export) * factor %} {% set beperkt = [ [verschil, 0] | max, cap ] | min %} {% set target = beperkt | int(0) %} {% set huidig = states('sensor.zendure_set_charge_power') | int(0) %} {{ huidig != target }}
           - alias: Lager dan maximaal ingestelde SOC
             condition: template
             value_template: |2-
@@ -1268,9 +1307,11 @@ actions:
             conditions:
               - condition: template
                 value_template: >
-                  {{ states('sensor.zendure_total_state_of_charge') | float |
+                  {{ has_value('sensor.zendure_total_state_of_charge')
+                  and has_value('sensor.zendure_minimum_state_of_charge')
+                  and states('sensor.zendure_total_state_of_charge') | float(0) |
                   round(0) >=
-                     states('sensor.zendure_minimum_state_of_charge') | float | round(0) }}
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) | round(0) }}
                 alias: SOC is gelijk of groter dan de minimale SOC
               - condition: state
                 entity_id: input_boolean.zendure_setting_soc_protection_disabled
@@ -1325,7 +1366,7 @@ actions:
                 float(0) %} {% set verschil = zendure - p1 - correctie_export %}
                 {% set beperkt = verschil * factor if verschil > 0 else 0 %} {%
                 set beperkt = beperkt if beperkt < cap else cap %} {{ beperkt |
-                int }}
+                int(0) }}
             action: rest_command.zendure_x_charge_balancing
           - action: logbook.log
             data:
@@ -1338,7 +1379,7 @@ actions:
                   {% set verschil = zendure - p1 - correctie_export %}
                   {% set beperkt = verschil * factor if verschil > 0 else 0 %}
                   {% set beperkt = beperkt if beperkt < cap else cap %}
-                  {{ beperkt | int }} watt —
+                  {{ beperkt | int(0) }} watt —
               entity_id: input_select.zendure_operation_mode
               name: " "
         alias: During charging balance to -xxx watt (100% of the demand)
@@ -1362,18 +1403,20 @@ actions:
             above: -1
           - condition: template
             value_template: |-
-              {{ states('input_number.zendure_manual_power') | int | abs !=
-                 states('sensor.zendure_set_charge_power') | int }}
+              {{ has_value('input_number.zendure_manual_power')
+              and has_value('sensor.zendure_set_charge_power')
+              and states('input_number.zendure_manual_power') | int(0) | abs !=
+                 states('sensor.zendure_set_charge_power') | int(0) }}
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
-              inputLimit: "{{ states('input_number.zendure_manual_power') | int | abs }}"
+              inputLimit: "{{ states('input_number.zendure_manual_power') | int(0) | abs }}"
             action: rest_command.zendure_x_charge
           - action: logbook.log
             data:
               message: >
                 ⚡Manual (Charging) — Power set to {{
-                states('input_number.zendure_manual_power') | int | abs }} watt
+                states('input_number.zendure_manual_power') | int(0) | abs }} watt
                 —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -1396,18 +1439,20 @@ actions:
             below: 1
           - condition: template
             value_template: |-
-              {{ states('input_number.zendure_manual_power') | int | abs !=
-                 states('sensor.zendure_set_discharge_power') | int }}
+              {{ has_value('input_number.zendure_manual_power')
+              and has_value('sensor.zendure_set_discharge_power')
+              and states('input_number.zendure_manual_power') | int(0) | abs !=
+                 states('sensor.zendure_set_discharge_power') | int(0) }}
         sequence:
           - data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
-              outputLimit: "{{ states('input_number.zendure_manual_power') | int | abs }}"
+              outputLimit: "{{ states('input_number.zendure_manual_power') | int(0) | abs }}"
             action: rest_command.zendure_x_discharge
           - action: logbook.log
             data:
               message: >
                 ⚡Manual (Discharging) — Power set to {{
-                states('input_number.zendure_manual_power') | int | abs }} watt
+                states('input_number.zendure_manual_power') | int(0) | abs }} watt
                 —
               entity_id: input_select.zendure_operation_mode
               name: " "
@@ -1431,7 +1476,7 @@ actions:
             data:
               value: >-
                 {{ states('input_number.dynamic_lowest_price_x_period_tomorrow')
-                | float }}
+                | float(0) }}
             action: input_number.set_value
           - alias: Zet duurste periode van morgen naar vandaag
             target:
@@ -1440,7 +1485,7 @@ actions:
               value: >-
                 {{
                 states('input_number.dynamic_highest_price_x_period_tomorrow') |
-                float }}
+                float(0) }}
             action: input_number.set_value
           - alias: Zet handmatige periode van morgen naar vandaag
             target:
@@ -1586,8 +1631,10 @@ actions:
               input_number.dynamic_setting_minimal_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamic_spread_indication_dsc') | float >=
-              states('input_number.dynamic_setting_minimal_spread') | float }}
+              {{ has_value('sensor.dynamic_spread_indication_dsc')
+              and has_value('input_number.dynamic_setting_minimal_spread')
+              and states('sensor.dynamic_spread_indication_dsc') | float(0) >=
+              states('input_number.dynamic_setting_minimal_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamic_charging_running
             state:
@@ -1610,7 +1657,7 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
+                {{ states('input_number.zendure_setting_max_charge_power') | int(0)
                 }}
           - action: logbook.log
             data:
@@ -1705,8 +1752,10 @@ actions:
               input_number.dynamic_setting_minimal_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamic_spread_indication') | float >=
-              states('input_number.dynamic_setting_minimal_spread') | float }}
+              {{ has_value('sensor.dynamic_spread_indication')
+              and has_value('input_number.dynamic_setting_minimal_spread')
+              and states('sensor.dynamic_spread_indication') | float(0) >=
+              states('input_number.dynamic_setting_minimal_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamic_charging_running
             state:
@@ -1729,7 +1778,7 @@ actions:
             data:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               inputLimit: >-
-                {{ states('input_number.zendure_setting_max_charge_power') | int
+                {{ states('input_number.zendure_setting_max_charge_power') | int(0)
                 }}
           - action: logbook.log
             data:
@@ -1807,8 +1856,10 @@ actions:
           - alias: Up to the minimum configured SOC
             condition: template
             value_template: |
-              {{ states('sensor.zendure_total_state_of_charge') | float >
-               states('sensor.zendure_minimum_state_of_charge') | float }}
+              {{ has_value('sensor.zendure_total_state_of_charge')
+              and has_value('sensor.zendure_minimum_state_of_charge')
+              and states('sensor.zendure_total_state_of_charge') | float(0) >
+               states('sensor.zendure_minimum_state_of_charge') | float(0) }}
           - condition: state
             entity_id: sensor.dynamic_highest_price_period
             state:
@@ -1818,8 +1869,10 @@ actions:
               input_number.dynamic_setting_minimal_spread
             condition: template
             value_template: >-
-              {{ states('sensor.dynamic_spread_indication') | float >=
-              states('input_number.dynamic_setting_minimal_spread') | float }}
+              {{ has_value('sensor.dynamic_spread_indication')
+              and has_value('input_number.dynamic_setting_minimal_spread')
+              and states('sensor.dynamic_spread_indication') | float(0) >=
+              states('input_number.dynamic_setting_minimal_spread') | float(0) }}
           - condition: state
             entity_id: input_boolean.dynamic_discharging_running
             state:
@@ -1843,7 +1896,7 @@ actions:
               sn: "{{ states('sensor.zendure_serial_number') }}"
               outputLimit: >-
                 {{ states('input_number.zendure_setting_max_discharge_power') |
-                int }}
+                int(0) }}
           - action: logbook.log
             data:
               message: 💲Dynamic expensive discharge started —
@@ -1853,8 +1906,10 @@ actions:
               - alias: Tot minimale SOC
                 trigger: template
                 value_template: |-
-                  {{ states('sensor.zendure_total_state_of_charge') | float <=
-                     states('sensor.zendure_minimum_state_of_charge') | float }}
+                  {{ has_value('sensor.zendure_total_state_of_charge')
+                  and has_value('sensor.zendure_minimum_state_of_charge')
+                  and states('sensor.zendure_total_state_of_charge') | float(0) <=
+                     states('sensor.zendure_minimum_state_of_charge') | float(0) }}
                 for:
                   hours: 0
                   minutes: 0

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -941,7 +941,7 @@ template:
         state: >
           {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
           {% set handmatige = states('input_text.dynamic_manual_period') %}
-          {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
+          {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int(0) %}
           {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
           {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
           {% if prijzen is iterable %}
@@ -1001,8 +1001,8 @@ template:
           raw_today: >
             {% set prijzen = state_attr('sensor.dynamic_lowest_price_period', 'raw_today') %}
             {% set handmatige = states('input_text.dynamic_manual_period') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int(0) %}
             {% if prijzen is iterable %}
               {% set ns = namespace(goede_starttijden=[], dure_starttijden=[]) %}
               {% if handmatige | length > 0 %}
@@ -1049,7 +1049,7 @@ template:
         state: >
           {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
           {% set handmatige = states('input_text.dynamic_manual_period') %}
-          {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
+          {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int(0) %}
           {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
           {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
           {% if prijzen is iterable %}
@@ -1105,8 +1105,8 @@ template:
           raw_today: >
             {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_today') %}
             {% set handmatige = states('input_text.dynamic_manual_period') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period') | int(0) %}
             {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
             {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
             {% if prijzen is iterable %}
@@ -1173,8 +1173,8 @@ template:
           raw_tomorrow: >
             {% set prijzen = state_attr('sensor.dynamic_nordpool', 'raw_tomorrow') %}
             {% set handmatige = states('input_text.dynamic_manual_period_tomorrow') %}
-            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period_tomorrow') | int %}
-            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period_tomorrow') | int %}
+            {% set aantal_goedkoop = states('input_number.dynamic_lowest_price_x_period_tomorrow') | int(0) %}
+            {% set aantal_duur = states('input_number.dynamic_highest_price_x_period_tomorrow') | int(0) %}
             {% set kwartier = is_state('input_boolean.dynamic_setting_15_minute_interval', 'on') %}
             {% set default_delta = timedelta(minutes=15) if kwartier else timedelta(hours=1) %}
             {% if prijzen is iterable %}


### PR DESCRIPTION
The globale Automation logs "float got invalid input 'unavailable'" in bursts whenever the Zendure REST sensors briefly drop out (reported for v20260824, e.g. the charge power comparison around line 674). The affected choose branch is skipped for that run and the next 5-second cycle recovers, but the WARNING noise is real.

Two rules were applied per site, not a blanket replace:

1. Every "| float" / "| int" gets an explicit "(0)".

2. Where an undefaulted filter sat on an entity state inside a value_template (a condition or a template trigger), that entity also gets a has_value() guard. A plain 0 default would not keep the old behaviour there: comparing a fabricated 0 against a configured limit flips the condition to true and re-pushes REST commands (with logbook entries) on every dropout, and in the SOC protection branch it would read a missing SOC as an empty battery. The guard keeps the branch false while the entity has no value, which is what the erroring template effectively did.

The four "adjust device setting" branches additionally get an availability condition on their input_number. They are entered from a plain state trigger on that helper, which also fires when the helper itself becomes unknown, and with an explicit default that would write a 0 as chargeMaxLimit / inverseMaxPower / socSet / minSoc into the battery.

Deliberately left without defaults: the package REST templates reading value_json / packData. A missing field there must keep the sensor unavailable instead of publishing a fake 0 W, and the pack-order templates already branch on unknown/unavailable themselves, where an "| int(0)" would turn a bad entry into pack index -1. Only the eight dynamic period-count reads from input_number helpers were defaulted.

Verified by re-rendering all 124 templates per automation file:
- no float/int errors with sensors unavailable, or with every entity unknown, where 23 per file raised before;
- of the 14 conditions whose result changes on a dropout, all 14 now resolve to false (branch skipped); none newly resolve to true.