### PR TITLE
Refactor unique_id for utility meters in Dutch and Global integration…

### DIFF
--- a/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
+++ b/Dutch (NL) Integration/packages/zendure_gielz1986_nl.yaml
@@ -336,7 +336,7 @@ sensor:
 utility_meter:
   zendure_2400_ac_pv_import_dagelijks:
     source: sensor.zendure_2400_ac_pv_import
-    unique_id: utility_meter.zendure_2400_ac_pv_import_dagelijks
+    unique_id: zendure_2400_ac_pv_import_dagelijks
     name: Zendure 2400 AC PV Import Dagelijks
     cycle: daily
 

--- a/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
+++ b/Global (EN) Integration/packages/zendure_gielz1986_global.yaml
@@ -336,7 +336,7 @@ sensor:
 utility_meter:
   zendure_pv_import_daily:
     source: sensor.zendure_pv_import
-    unique_id: utility_meter.zendure_pv_import_daily
+    unique_id: zendure_pv_import_daily
     name: Zendure PV Import Daily
     cycle: daily
 


### PR DESCRIPTION
**What I experienced:**
Watchman reported utility_meter.zendure_pv_import_daily as a missing entity, despite the daily PV import sensor being defined and used as sensor.zendure_pv_import_daily. The cause was the unique_id for the utility meter: it included the utility_meter. entity-domain prefix. Since unique_id values are internal identifiers rather than entity IDs, the prefix was invalid and was parsed by Watchman as an entity reference. The fix changes both the English and Dutch utility-meter unique_id values to domain-free identifiers, matching Home Assistant conventions.

**Fix utility meter unique IDs**:

Remove the `utility_meter.` domain prefix from the daily PV import meter unique IDs. A `unique_id` is an internal registry identifier, not an entity ID, so including a domain made Watchman interpret it as a reference to the non-existent `utility_meter.zendure_pv_import_daily` entity. The utility meter itself correctly creates `sensor.zendure_pv_import_daily`. The equivalent Dutch configuration has been corrected as well.

(see related issue: https://github.com/Gielz1986/Zendure-HA-zenSDK/issues/182)